### PR TITLE
feat: Support using Android versionCode for patch checks

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,9 +21,9 @@ fn main() {
 
     let config = updater::AppConfig {
         cache_dir: "updater_cache".to_owned(),
-        release_version: "0.1.0".to_owned(),
+        version_name: "0.1.0".to_owned(),
+        version_code: 1,
         original_libapp_paths: vec!["libapp.so".to_owned()],
-        vm_path: "libflutter.so".to_owned(),
     };
     let yaml_str = "
 app_id: demo

--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -21,10 +21,15 @@
  */
 typedef struct AppParameters {
   /**
-   * release_version, required.  Named version of the app, off of which updates
+   * version_name, required.  Named version of the app, off of which updates
    * are based.  Can be either a version number or a hash.
    */
-  const char *release_version;
+  const char *version_name;
+  /**
+   * version_code, required.  Integer version of the app, off of which
+   * updates are based.  Monotonically increasing on Android/Play Store.
+   */
+  long version_code;
   /**
    * Array of paths to the original aot library, required.  For Flutter apps
    * these are the paths to the bundled libapp.so.  May be used for compression downloaded artifacts.
@@ -34,14 +39,6 @@ typedef struct AppParameters {
    * Length of the original_libapp_paths array.
    */
   int original_libapp_paths_size;
-  /**
-   * Path to the app's libflutter.so, required.  May be used for ensuring
-   * downloaded artifacts are compatible with the Flutter/Dart versions
-   * used by the app.  For Flutter apps this should be the path to the
-   * bundled libflutter.so.  For Dart apps this should be the path to the
-   * dart executable.
-   */
-  const char *vm_path;
   /**
    * Path to cache_dir where the updater will store downloaded artifacts.
    */

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -14,9 +14,13 @@ use crate::updater;
 /// NOTE: If this struct is changed all language bindings must be updated.
 #[repr(C)]
 pub struct AppParameters {
-    /// release_version, required.  Named version of the app, off of which updates
+    /// version_name, required.  Named version of the app, off of which updates
     /// are based.  Can be either a version number or a hash.
-    pub release_version: *const libc::c_char,
+    pub version_name: *const libc::c_char,
+
+    /// version_code, required.  Integer version of the app, off of which
+    /// updates are based.  Monotonically increasing on Android/Play Store.
+    pub version_code: libc::c_long,
 
     /// Array of paths to the original aot library, required.  For Flutter apps
     /// these are the paths to the bundled libapp.so.  May be used for compression downloaded artifacts.
@@ -24,13 +28,6 @@ pub struct AppParameters {
 
     /// Length of the original_libapp_paths array.
     pub original_libapp_paths_size: libc::c_int,
-
-    /// Path to the app's libflutter.so, required.  May be used for ensuring
-    /// downloaded artifacts are compatible with the Flutter/Dart versions
-    /// used by the app.  For Flutter apps this should be the path to the
-    /// bundled libflutter.so.  For Dart apps this should be the path to the
-    /// dart executable.
-    pub vm_path: *const libc::c_char,
 
     /// Path to cache_dir where the updater will store downloaded artifacts.
     pub cache_dir: *const libc::c_char,
@@ -54,12 +51,12 @@ fn app_config_from_c(c_params: *const AppParameters) -> updater::AppConfig {
 
     updater::AppConfig {
         cache_dir: to_rust(c_params_ref.cache_dir),
-        release_version: to_rust(c_params_ref.release_version),
+        version_name: to_rust(c_params_ref.version_name),
+        version_code: c_params_ref.version_code,
         original_libapp_paths: to_rust_vector(
             c_params_ref.original_libapp_paths,
             c_params_ref.original_libapp_paths_size,
         ),
-        vm_path: to_rust(c_params_ref.vm_path),
     }
 }
 

--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -128,7 +128,10 @@ impl UpdaterState {
             Self::new(cache_dir.to_owned(), version_name.to_owned(), version_code)
         });
         if loaded.version_name != version_name {
-            info!("Release version changed, clearing updater state");
+            info!("version_name changed {} -> {}, clearing updater state", loaded.version_name, version_name);
+            Self::new(cache_dir.to_owned(), version_name.to_owned(), version_code)
+        } else if loaded.version_code != version_code {
+            info!("version_code changed {} -> {}, clearing updater state", loaded.version_code, version_code);
             Self::new(cache_dir.to_owned(), version_name.to_owned(), version_code)
         } else {
             loaded
@@ -355,7 +358,7 @@ mod tests {
         assert_eq!(loaded.latest_downloaded_patch, Some(1));
 
         let loaded_after_version_change =
-            UpdaterState::load_or_new_on_error(&state.cache_dir, &state.version_name, 2 );
+            UpdaterState::load_or_new_on_error(&state.cache_dir, &state.version_name, 2);
         assert_eq!(loaded_after_version_change.latest_downloaded_patch, None);
     }
 

--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -128,10 +128,16 @@ impl UpdaterState {
             Self::new(cache_dir.to_owned(), version_name.to_owned(), version_code)
         });
         if loaded.version_name != version_name {
-            info!("version_name changed {} -> {}, clearing updater state", loaded.version_name, version_name);
+            info!(
+                "version_name changed {} -> {}, clearing updater state",
+                loaded.version_name, version_name
+            );
             Self::new(cache_dir.to_owned(), version_name.to_owned(), version_code)
         } else if loaded.version_code != version_code {
-            info!("version_code changed {} -> {}, clearing updater state", loaded.version_code, version_code);
+            info!(
+                "version_code changed {} -> {}, clearing updater state",
+                loaded.version_code, version_code
+            );
             Self::new(cache_dir.to_owned(), version_name.to_owned(), version_code)
         } else {
             loaded
@@ -340,11 +346,15 @@ mod tests {
         let mut state = test_state(&tmp_dir);
         state.latest_downloaded_patch = Some(1);
         state.save().unwrap();
-        let loaded = UpdaterState::load_or_new_on_error(&state.cache_dir, &state.version_name, state.version_code);
+        let loaded = UpdaterState::load_or_new_on_error(
+            &state.cache_dir,
+            &state.version_name,
+            state.version_code,
+        );
         assert_eq!(loaded.latest_downloaded_patch, Some(1));
 
         let loaded_after_version_change =
-            UpdaterState::load_or_new_on_error(&state.cache_dir, "1.0.1", state.version_code );
+            UpdaterState::load_or_new_on_error(&state.cache_dir, "1.0.1", state.version_code);
         assert_eq!(loaded_after_version_change.latest_downloaded_patch, None);
     }
 
@@ -354,7 +364,11 @@ mod tests {
         let mut state = test_state(&tmp_dir);
         state.latest_downloaded_patch = Some(1);
         state.save().unwrap();
-        let loaded = UpdaterState::load_or_new_on_error(&state.cache_dir, &state.version_name, state.version_code);
+        let loaded = UpdaterState::load_or_new_on_error(
+            &state.cache_dir,
+            &state.version_name,
+            state.version_code,
+        );
         assert_eq!(loaded.latest_downloaded_patch, Some(1));
 
         let loaded_after_version_change =

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -39,7 +39,8 @@ pub struct ResolvedConfig {
     pub download_dir: String,
     pub channel: String,
     pub app_id: String,
-    pub release_version: String,
+    pub version_name: String,
+    pub version_code: i64,
     pub original_libapp_paths: Vec<String>,
     pub vm_path: String,
     pub base_url: String,
@@ -53,7 +54,8 @@ impl ResolvedConfig {
             download_dir: String::new(),
             channel: String::new(),
             app_id: String::new(),
-            release_version: String::new(),
+            version_name: String::new(),
+            version_code: 0,
             original_libapp_paths: Vec::new(),
             vm_path: String::new(),
             base_url: String::new(),
@@ -82,9 +84,9 @@ pub fn set_config(config: AppConfig, yaml: YamlConfig) {
     cache_path.push("downloads");
     lock.download_dir = cache_path.to_str().unwrap().to_string();
     lock.app_id = yaml.app_id.to_string();
-    lock.release_version = config.release_version.to_string();
+    lock.version_name = config.version_name.to_string();
+    lock.version_code = config.version_code;
     lock.original_libapp_paths = config.original_libapp_paths;
-    lock.vm_path = config.vm_path.to_string();
     lock.is_initialized = true;
     info!("Updater configured with: {:?}", lock);
 }

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -37,6 +37,7 @@ pub struct PatchCheckRequest {
     /// The latest patch number that the client has downloaded.
     /// Not necessarily the one it's running (if some have been marked bad).
     /// We could rename this to be more clear.
+    pub version_code: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub patch_number: Option<usize>,
     /// Platform (e.g. "android", "ios", "windows", "macos", "linux").
@@ -63,7 +64,8 @@ pub fn send_patch_check_request(
     let req = PatchCheckRequest {
         app_id: config.app_id.clone(),
         channel: config.channel.clone(),
-        release_version: config.release_version.clone(),
+        release_version: config.version_name.clone(),
+        version_code: config.version_code,
         patch_number: latest_patch_number,
         platform: current_platform().to_string(),
         arch: current_arch().to_string(),

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -82,7 +82,11 @@ pub fn init(app_config: AppConfig, yaml: &str) -> Result<(), UpdateError> {
 fn check_for_update_internal(config: &ResolvedConfig) -> bool {
     // Load UpdaterState from disk
     // If there is no state, make an empty state.
-    let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
+    let state = UpdaterState::load_or_new_on_error(
+        &config.cache_dir,
+        &config.version_name,
+        config.version_code,
+    );
     // Send info from app + current slot to server.
     let response_result = send_patch_check_request(&config, &state);
     match response_result {
@@ -274,7 +278,11 @@ fn open_base_lib(apks_dir: &Path, lib_name: &str) -> anyhow::Result<Cursor<Vec<u
 // Run the update logic with the resolved config.
 fn update_internal(config: &ResolvedConfig) -> anyhow::Result<UpdateStatus> {
     // Load the state from disk.
-    let mut state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
+    let mut state = UpdaterState::load_or_new_on_error(
+        &config.cache_dir,
+        &config.version_name,
+        config.version_code,
+    );
     // Check for update.
     let response = send_patch_check_request(&config, &state)?;
     if !response.patch_available {
@@ -385,7 +393,11 @@ where
 /// Reads the current patch from the cache and returns it.
 pub fn active_patch() -> Option<PatchInfo> {
     return with_config(|config| {
-        let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
+        let state = UpdaterState::load_or_new_on_error(
+            &config.cache_dir,
+            &config.version_name,
+            config.version_code,
+        );
         return state.current_patch();
     });
 }
@@ -395,8 +407,11 @@ pub fn active_patch() -> Option<PatchInfo> {
 pub fn report_failed_launch() -> Result<(), UpdateError> {
     info!("Reporting failed launch.");
     with_config(|config| {
-        let mut state =
-            UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
+        let mut state = UpdaterState::load_or_new_on_error(
+            &config.cache_dir,
+            &config.version_name,
+            config.version_code,
+        );
 
         // FIXME: We need to separate out the concept of "running patch" and
         // "next patch to activate".  Currently these are smooshed which will
@@ -411,8 +426,11 @@ pub fn report_failed_launch() -> Result<(), UpdateError> {
 
 pub fn report_successful_launch() -> Result<(), UpdateError> {
     with_config(|config| {
-        let mut state =
-            UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
+        let mut state = UpdaterState::load_or_new_on_error(
+            &config.cache_dir,
+            &config.version_name,
+            config.version_code,
+        );
 
         let patch = state
             .current_patch()
@@ -511,8 +529,11 @@ mod tests {
             fs::create_dir_all(&download_dir).unwrap();
             fs::write(&artifact_path, "hello").unwrap();
 
-            let mut state =
-                UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
+            let mut state = UpdaterState::load_or_new_on_error(
+                &config.cache_dir,
+                &config.version_name,
+                config.version_code,
+            );
             state
                 .install_patch(PatchInfo {
                     path: artifact_path.to_str().unwrap().to_string(),

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -61,9 +61,9 @@ impl Display for UpdateError {
 // but making &str from CStr* is a bit of a pain.
 pub struct AppConfig {
     pub cache_dir: String,
-    pub release_version: String,
+    pub version_name: String,
+    pub version_code: i64,
     pub original_libapp_paths: Vec<String>,
-    pub vm_path: String,
 }
 
 /// Initialize the updater library.
@@ -82,7 +82,7 @@ pub fn init(app_config: AppConfig, yaml: &str) -> Result<(), UpdateError> {
 fn check_for_update_internal(config: &ResolvedConfig) -> bool {
     // Load UpdaterState from disk
     // If there is no state, make an empty state.
-    let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+    let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
     // Send info from app + current slot to server.
     let response_result = send_patch_check_request(&config, &state);
     match response_result {
@@ -274,7 +274,7 @@ fn open_base_lib(apks_dir: &Path, lib_name: &str) -> anyhow::Result<Cursor<Vec<u
 // Run the update logic with the resolved config.
 fn update_internal(config: &ResolvedConfig) -> anyhow::Result<UpdateStatus> {
     // Load the state from disk.
-    let mut state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+    let mut state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
     // Check for update.
     let response = send_patch_check_request(&config, &state)?;
     if !response.patch_available {
@@ -385,7 +385,7 @@ where
 /// Reads the current patch from the cache and returns it.
 pub fn active_patch() -> Option<PatchInfo> {
     return with_config(|config| {
-        let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+        let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
         return state.current_patch();
     });
 }
@@ -396,7 +396,7 @@ pub fn report_failed_launch() -> Result<(), UpdateError> {
     info!("Reporting failed launch.");
     with_config(|config| {
         let mut state =
-            UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+            UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
 
         // FIXME: We need to separate out the concept of "running patch" and
         // "next patch to activate".  Currently these are smooshed which will
@@ -412,7 +412,7 @@ pub fn report_failed_launch() -> Result<(), UpdateError> {
 pub fn report_successful_launch() -> Result<(), UpdateError> {
     with_config(|config| {
         let mut state =
-            UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+            UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
 
         let patch = state
             .current_patch()
@@ -447,9 +447,9 @@ mod tests {
         crate::init(
             crate::AppConfig {
                 cache_dir: cache_dir.clone(),
-                release_version: "1.0.0".to_string(),
+                version_name: "1.0.0".to_string(),
+                version_code: 1,
                 original_libapp_paths: vec!["original_libapp_path".to_string()],
-                vm_path: "vm_path".to_string(),
             },
             "app_id: 1234",
         )
@@ -464,9 +464,9 @@ mod tests {
             crate::init(
                 crate::AppConfig {
                     cache_dir: cache_dir.clone(),
-                    release_version: "1.0.0".to_string(),
+                    version_name: "1.0.0".to_string(),
+                    version_code: 1,
                     original_libapp_paths: vec!["original_libapp_path".to_string()],
-                    vm_path: "vm_path".to_string(),
                 },
                 "",
             ),
@@ -512,7 +512,7 @@ mod tests {
             fs::write(&artifact_path, "hello").unwrap();
 
             let mut state =
-                UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+                UpdaterState::load_or_new_on_error(&config.cache_dir, &config.version_name, config.version_code);
             state
                 .install_patch(PatchInfo {
                     path: artifact_path.to_str().unwrap().to_string(),


### PR DESCRIPTION
The rust plumbing for adding version_code.

Renamed release_version to version_name, add version_code, removed vm_path.

Also added version_code changing as a reason to invalidate the cache dir.