### PR TITLE
refactor: C API to avoid using unwrap.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "cSpell.words": [
+        "aarch",
+        "armeabi",
+        "bipatch",
+        "bootable",
+        "canonicalize",
+        "cbindgen",
+        "comde",
+        "Decompressor",
+        "hasher",
+        "libapp",
+        "libc",
+        "repr",
+        "reqwest",
+        "tempdir",
+        "vmcode"
+    ]
+}

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -7,6 +7,8 @@
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
+use anyhow::Context;
+
 use crate::updater;
 
 /// Struct containing configuration parameters for the updater.
@@ -31,34 +33,59 @@ pub struct AppParameters {
 }
 
 /// Converts a C string to a Rust string, does not free the C string.
-fn to_rust(c_string: *const libc::c_char) -> String {
-    unsafe { CStr::from_ptr(c_string).to_str().unwrap() }.to_string()
+fn to_rust(c_string: *const libc::c_char) -> anyhow::Result<String> {
+    anyhow::ensure!(!c_string.is_null(), "Null string passed to to_rust");
+    let c_str = unsafe { CStr::from_ptr(c_string) };
+    Ok(c_str.to_str()?.to_string())
 }
 
 /// Converts a Rust string to a C string, caller must free the C string.
-fn allocate_c_string(rust_string: &str) -> *mut c_char {
-    CString::new(rust_string).unwrap().into_raw()
+fn allocate_c_string(rust_string: &str) -> anyhow::Result<*mut c_char> {
+    let c_str = CString::new(rust_string)?;
+    Ok(c_str.into_raw())
 }
 
-fn to_rust_vector(c_array: *const *const libc::c_char, size: libc::c_int) -> Vec<String> {
+fn to_rust_vector(
+    c_array: *const *const libc::c_char,
+    size: libc::c_int,
+) -> anyhow::Result<Vec<String>> {
     let mut result = Vec::new();
     for i in 0..size {
         let c_string = unsafe { *c_array.offset(i as isize) };
-        result.push(to_rust(c_string));
+        result.push(to_rust(c_string)?);
     }
-    result
+    Ok(result)
 }
 
-fn app_config_from_c(c_params: *const AppParameters) -> updater::AppConfig {
+fn app_config_from_c(c_params: *const AppParameters) -> anyhow::Result<updater::AppConfig> {
+    anyhow::ensure!(
+        !c_params.is_null(),
+        "Null parameters passed to app_config_from_c"
+    );
     let c_params_ref = unsafe { &*c_params };
 
-    updater::AppConfig {
-        cache_dir: to_rust(c_params_ref.cache_dir),
-        release_version:to_rust(c_params_ref.release_version),
+    Ok(updater::AppConfig {
+        cache_dir: to_rust(c_params_ref.cache_dir)?,
+        release_version: to_rust(c_params_ref.release_version)?,
         original_libapp_paths: to_rust_vector(
             c_params_ref.original_libapp_paths,
             c_params_ref.original_libapp_paths_size,
-        ),
+        )?,
+    })
+}
+
+/// Helper function to log errors instead of panicking or returning a result.
+fn log_on_error<F, R>(f: F, context: &str, default: R) -> R
+where
+    F: FnOnce() -> Result<R, anyhow::Error>,
+{
+    let result = f();
+    match result {
+        Ok(r) => r,
+        Err(e) => {
+            error!("Error {}: {:?}", context, e);
+            default
+        }
     }
 }
 
@@ -67,50 +94,52 @@ fn app_config_from_c(c_params: *const AppParameters) -> updater::AppConfig {
 /// configuration compiled into the app.
 #[no_mangle]
 pub extern "C" fn shorebird_init(c_params: *const AppParameters, c_yaml: *const libc::c_char) {
-    let config = app_config_from_c(c_params);
-
-    let yaml_string = to_rust(c_yaml);
-    let result = updater::init(config, &yaml_string);
-    match result {
-        Ok(_) => {}
-        Err(e) => {
-            error!("Error initializing updater: {:?}", e);
-        }
-    }
+    log_on_error(
+        || {
+            let config = app_config_from_c(c_params)?;
+            let yaml_string = to_rust(c_yaml)?;
+            let result = updater::init(config, &yaml_string)?;
+            Ok(result)
+        },
+        "initializing updater",
+        (),
+    )
 }
 
 /// Return the active patch number, or NULL if there is no active patch.
 #[no_mangle]
 pub extern "C" fn shorebird_next_boot_patch_number() -> *mut c_char {
-    let patch = updater::next_boot_patch();
-    match patch {
-        Some(p) => {
-            allocate_c_string(&p.number.to_string())
-        }
-        None => std::ptr::null_mut(),
-    }
+    log_on_error(
+        || {
+            let patch = updater::next_boot_patch().context("failed to fetch patch info")?;
+            allocate_c_string(&patch.number.to_string())
+        },
+        "fetching next_boot_patch_number",
+        std::ptr::null_mut(),
+    )
 }
 
 /// Return the path to the active patch for the app, or NULL if there is no
 /// active patch.
 #[no_mangle]
 pub extern "C" fn shorebird_next_boot_patch_path() -> *mut c_char {
-    let patch = updater::next_boot_patch();
-    match patch {
-        Some(p) => {
-            allocate_c_string(&p.path)
-        }
-        None => std::ptr::null_mut(),
-    }
+    log_on_error(
+        || {
+            let patch = updater::next_boot_patch().context("failed to fetch patch info")?;
+            allocate_c_string(&patch.path)
+        },
+        "fetching next_boot_patch_path",
+        std::ptr::null_mut(),
+    )
 }
 
 /// Free a string returned by the updater library.
 #[no_mangle]
 pub extern "C" fn shorebird_free_string(c_string: *mut c_char) {
+    if c_string.is_null() {
+        return;
+    }
     unsafe {
-        if c_string.is_null() {
-            return;
-        }
         drop(CString::from_raw(c_string));
     }
 }
@@ -140,13 +169,12 @@ pub extern "C" fn shorebird_start_update_thread() {
 /// shorebird_report_launch_success or shorebird_report_launch_failure.
 #[no_mangle]
 pub extern "C" fn shorebird_report_launch_start() {
-    let result = updater::report_launch_start();
-    match result {
-        Ok(_) => {}
-        Err(e) => {
-            error!("Error recording launch start: {:?}", e);
-        }
-    }
+    // Use log_on_error
+    log_on_error(
+        || updater::report_launch_start(),
+        "reporting launch start",
+        (),
+    );
 }
 
 /// Report that the app failed to launch.  This will cause the updater to
@@ -154,13 +182,14 @@ pub extern "C" fn shorebird_report_launch_start() {
 /// been launched successfully before.
 #[no_mangle]
 pub extern "C" fn shorebird_report_launch_failure() {
-    let result = updater::report_launch_failure();
-    match result {
-        Ok(_) => {}
-        Err(e) => {
-            error!("Error recording launch failure: {:?}", e);
-        }
-    }
+    log_on_error(
+        || {
+            updater::report_launch_failure()?;
+            Ok(())
+        },
+        "reporting launch failure",
+        (),
+    );
 }
 
 /// Report that the app launched successfully.  This will mark the current
@@ -172,11 +201,12 @@ pub extern "C" fn shorebird_report_launch_failure() {
 /// and then marks the launch as successful.  We could do something similar.
 #[no_mangle]
 pub extern "C" fn shorebird_report_launch_success() {
-    let result = updater::report_launch_success();
-    match result {
-        Ok(_) => {}
-        Err(e) => {
-            error!("Error recording launch success: {:?}", e);
-        }
-    }
+    log_on_error(
+        || {
+            updater::report_launch_success()?;
+            Ok(())
+        },
+        "reporting launch success",
+        (),
+    );
 }

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -169,7 +169,6 @@ pub extern "C" fn shorebird_start_update_thread() {
 /// shorebird_report_launch_success or shorebird_report_launch_failure.
 #[no_mangle]
 pub extern "C" fn shorebird_report_launch_start() {
-    // Use log_on_error
     log_on_error(
         || updater::report_launch_start(),
         "reporting launch start",

--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -159,7 +159,7 @@ impl UpdaterState {
     /// - The updater has been initialized but no boot recorded yet.
     pub fn current_boot_patch(&self) -> Option<PatchInfo> {
         if let Some(slot_index) = self.current_boot_slot_index {
-            return self.patch_info_at(slot_index)
+            return self.patch_info_at(slot_index);
         }
         None
     }
@@ -170,7 +170,7 @@ impl UpdaterState {
     /// - There was a patch selected but it was later marked as bad.
     pub fn next_boot_patch(&self) -> Option<PatchInfo> {
         if let Some(slot_index) = self.next_boot_slot_index {
-            return self.patch_info_at(slot_index)
+            return self.patch_info_at(slot_index);
         }
         None
     }
@@ -304,11 +304,13 @@ impl UpdaterState {
         self.save()?;
         Ok(())
     }
-    
+
     /// Sets the current_boot slot to the next_boot slot.
     pub fn activate_current_patch(&mut self) -> Result<(), UpdateError> {
-        if  self.next_boot_slot_index.is_none() {
-            return Err(UpdateError::InvalidState("No patch to activate.".to_owned()));
+        if self.next_boot_slot_index.is_none() {
+            return Err(UpdateError::InvalidState(
+                "No patch to activate.".to_owned(),
+            ));
         }
         self.current_boot_slot_index = self.next_boot_slot_index.clone();
         assert!(self.current_boot_slot_index.is_some());

--- a/library/tests/c_api_test.rs
+++ b/library/tests/c_api_test.rs
@@ -1,0 +1,33 @@
+mod common;
+
+use common::*;
+use tempdir::TempDir;
+use updater::c_api::*;
+
+#[test]
+fn init_with_nulls() {
+    // Should log but not crash.
+    shorebird_init(std::ptr::null(), std::ptr::null());
+}
+
+#[test]
+fn init_with_null_app_parameters() {
+    // Should log but not crash.
+    let c_params = AppParameters {
+        cache_dir: std::ptr::null(),
+        release_version: std::ptr::null(),
+        original_libapp_paths: std::ptr::null(),
+        original_libapp_paths_size: 0,
+    };
+    shorebird_init(&c_params, std::ptr::null());
+}
+
+#[test]
+fn init_with_bad_yaml() {
+    let tmp_dir = TempDir::new("example").unwrap();
+    let c_params = parameters(&tmp_dir);
+    let c_yaml = c_string("bad yaml");
+    shorebird_init(&c_params, c_yaml);
+    free_c_string(c_yaml);
+    free_parameters(c_params);
+}

--- a/library/tests/common/mod.rs
+++ b/library/tests/common/mod.rs
@@ -1,0 +1,59 @@
+use std::ffi::CString;
+use tempdir::TempDir;
+
+pub fn c_string(string: &str) -> *mut libc::c_char {
+    let c_string = CString::new(string).unwrap().into_raw();
+    c_string
+}
+
+pub fn free_c_string(string: *mut libc::c_char) {
+    unsafe {
+        drop(CString::from_raw(string));
+    }
+}
+
+pub fn c_array(strings: Vec<String>) -> *mut *mut libc::c_char {
+    let mut c_strings = Vec::new();
+    for string in strings {
+        c_strings.push(c_string(&string));
+    }
+    // Make sure we're not wasting space.
+    c_strings.shrink_to_fit();
+    assert!(c_strings.len() == c_strings.capacity());
+
+    let ptr = c_strings.as_mut_ptr();
+    std::mem::forget(c_strings);
+    ptr
+}
+
+pub fn free_c_array(strings: *mut *mut libc::c_char, size: usize) {
+    let v = unsafe { Vec::from_raw_parts(strings, size, size) };
+
+    // Now drop one string at a time.
+    for string in v {
+        free_c_string(string);
+    }
+}
+
+pub fn parameters(tmp_dir: &TempDir) -> super::AppParameters {
+    let cache_dir = tmp_dir.path().to_str().unwrap().to_string();
+    let app_paths_vec = vec!["libapp.so".to_owned()];
+    let app_paths_size = app_paths_vec.len() as i32;
+    let app_paths = c_array(app_paths_vec);
+
+    super::AppParameters {
+        cache_dir: c_string(&cache_dir),
+        release_version: c_string("1.0.0"),
+        original_libapp_paths: app_paths as *const *const libc::c_char,
+        original_libapp_paths_size: app_paths_size,
+    }
+}
+
+pub fn free_parameters(params: super::AppParameters) {
+    free_c_string(params.cache_dir as *mut libc::c_char);
+    free_c_string(params.release_version as *mut libc::c_char);
+    free_c_array(
+        params.original_libapp_paths as *mut *mut libc::c_char,
+        params.original_libapp_paths_size as usize,
+    )
+}

--- a/library/tests/updater_test.rs
+++ b/library/tests/updater_test.rs
@@ -1,0 +1,53 @@
+use tempdir::TempDir;
+use updater::*;
+
+fn init_for_testing(tmp_dir: &TempDir) {
+    let cache_dir = tmp_dir.path().to_str().unwrap().to_string();
+    crate::init(
+        crate::AppConfig {
+            cache_dir: cache_dir.clone(),
+            release_version: "1.0.0+1".to_string(),
+            original_libapp_paths: vec!["original_libapp_path".to_string()],
+        },
+        "app_id: 1234",
+    )
+    .unwrap();
+}
+
+#[test]
+fn init_missing_yaml() {
+    let tmp_dir = TempDir::new("example").unwrap();
+    let cache_dir = tmp_dir.path().to_str().unwrap().to_string();
+    assert_eq!(
+        crate::init(
+            crate::AppConfig {
+                cache_dir: cache_dir.clone(),
+                release_version: "1.0.0+1".to_string(),
+                original_libapp_paths: vec!["original_libapp_path".to_string()],
+            },
+            "",
+        ),
+        Err(crate::UpdateError::InvalidArgument(
+            "yaml".to_string(),
+            "missing field `app_id`".to_string()
+        ))
+    );
+}
+
+#[test]
+fn report_launch_result_with_no_current_patch() {
+    let tmp_dir = TempDir::new("example").unwrap();
+    init_for_testing(&tmp_dir);
+    assert_eq!(
+        crate::report_launch_failure(),
+        Err(crate::UpdateError::InvalidState(
+            "No current patch".to_string()
+        ))
+    );
+    assert_eq!(
+        crate::report_launch_success(),
+        Err(crate::UpdateError::InvalidState(
+            "No current patch".to_string()
+        ))
+    );
+}


### PR DESCRIPTION
This removes another source of possible crashes from the rust code.

I also took this opportunity to try and test the C-api. I also discovered rust "integration tests" as part of this and chose to move some of the (new) c_api tests to an integration test as well as the existing rust api (updater.rs) tests.