### PR TITLE
fix: don't panic on missing shorebird.yaml

### DIFF
--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -11,7 +11,7 @@ use crate::updater;
 
 // https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests
 #[cfg(test)]
-use std::println as error; // Workaround to use println! for logs.
+use std::{println as info, println as error}; // Workaround to use println! for logs.
 
 /// Struct containing configuration parameters for the updater.
 /// Passed to all updater functions.
@@ -164,10 +164,7 @@ pub extern "C" fn shorebird_check_for_update() -> bool {
 #[no_mangle]
 pub extern "C" fn shorebird_update() {
     log_on_error(
-        || {
-            updater::update()?;
-            Ok(())
-        },
+        || updater::update().and_then(|result| Ok(info!("Update result: {}", result))),
         "downloading update",
         (),
     );

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -1,6 +1,4 @@
 // This file handles the global config for the updater library.
-use anyhow::bail;
-
 #[cfg(test)]
 use crate::network::{DownloadFileFn, PatchCheckRequestFn};
 #[cfg(test)]
@@ -67,7 +65,7 @@ where
     F: FnOnce(&ResolvedConfig) -> anyhow::Result<R>,
 {
     if !config.is_initialized {
-        bail!(UpdateError::ConfigNotInitialized);
+        anyhow::bail!(UpdateError::ConfigNotInitialized);
     }
     return f(&config);
 }

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -64,18 +64,18 @@ pub fn testing_reset_config() {
 
 pub fn check_initialized_and_call<F, R>(f: F, config: &ResolvedConfig) -> anyhow::Result<R>
 where
-    F: FnOnce(&ResolvedConfig) -> R,
+    F: FnOnce(&ResolvedConfig) -> anyhow::Result<R>,
 {
     if !config.is_initialized {
         bail!(UpdateError::ConfigNotInitialized);
     }
-    return Ok(f(&config));
+    return f(&config);
 }
 
 #[cfg(test)]
-pub fn with_thread_config<F, R>(f: F) -> R
+pub fn with_thread_config<F, R>(f: F) -> anyhow::Result<R>
 where
-    F: FnOnce(&ThreadConfig) -> R,
+    F: FnOnce(&ThreadConfig) -> anyhow::Result<R>,
 {
     THREAD_CONFIG.with(|thread_config| {
         let thread_config = thread_config.borrow();
@@ -97,7 +97,7 @@ where
 #[cfg(not(test))]
 pub fn with_config<F, R>(f: F) -> anyhow::Result<R>
 where
-    F: FnOnce(&ResolvedConfig) -> R,
+    F: FnOnce(&ResolvedConfig) -> anyhow::Result<R>,
 {
     // expect() here should be OK, it's job is to propagate a panic across
     // threads if the lock is poisoned.
@@ -110,7 +110,7 @@ where
 #[cfg(test)]
 pub fn with_config<F, R>(f: F) -> anyhow::Result<R>
 where
-    F: FnOnce(&ResolvedConfig) -> R,
+    F: FnOnce(&ResolvedConfig) -> anyhow::Result<R>,
 {
     // Rust unit tests run on multiple threads in parallel, so we use
     // a per-thread config when unit testing instead of a global config.

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -1,4 +1,5 @@
 // This file handles the global config for the updater library.
+use anyhow::bail;
 
 #[cfg(test)]
 use crate::network::{DownloadFileFn, PatchCheckRequestFn};
@@ -7,6 +8,7 @@ use std::cell::RefCell;
 
 use crate::updater::AppConfig;
 use crate::yaml::YamlConfig;
+use crate::UpdateError;
 
 #[cfg(not(test))]
 use once_cell::sync::OnceCell;
@@ -60,14 +62,14 @@ pub fn testing_reset_config() {
     });
 }
 
-pub fn check_initialized_and_call<F, R>(f: F, config: &ResolvedConfig) -> R
+pub fn check_initialized_and_call<F, R>(f: F, config: &ResolvedConfig) -> anyhow::Result<R>
 where
     F: FnOnce(&ResolvedConfig) -> R,
 {
     if !config.is_initialized {
-        panic!("Must call shorebird_init() before using the updater.");
+        bail!(UpdateError::ConfigNotInitialized);
     }
-    return f(&config);
+    return Ok(f(&config));
 }
 
 #[cfg(test)]
@@ -93,7 +95,7 @@ where
 }
 
 #[cfg(not(test))]
-pub fn with_config<F, R>(f: F) -> R
+pub fn with_config<F, R>(f: F) -> anyhow::Result<R>
 where
     F: FnOnce(&ResolvedConfig) -> R,
 {
@@ -106,7 +108,7 @@ where
 }
 
 #[cfg(test)]
-pub fn with_config<F, R>(f: F) -> R
+pub fn with_config<F, R>(f: F) -> anyhow::Result<R>
 where
     F: FnOnce(&ResolvedConfig) -> R,
 {

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -5,7 +5,7 @@
 // C doesn't care about the namespaces, but Rust does.
 pub mod c_api;
 
-// Declare other .rs file/module exists, but make them public.
+// Declare other .rs file/module exists, but make them private.
 mod cache;
 mod config;
 mod logging;

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -97,18 +97,8 @@ pub fn check_for_update() -> anyhow::Result<bool> {
         // Load UpdaterState from disk
         // If there is no state, make an empty state.
         let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
-        // Send info from app + current slot to server.
-        let response_result = send_patch_check_request(&config, &state);
-        match response_result {
-            Err(err) => {
-                error!("Failed update check: {err}");
-                return false;
-            }
-            Ok(response) => {
-                return response.patch_available;
-            }
-        }
-    })
+        send_patch_check_request(&config, &state).map(|res| res.patch_available)
+    })?
 }
 
 fn check_hash(path: &Path, expected_string: &str) -> anyhow::Result<bool> {

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -1,15 +1,17 @@
 // This file's job is to be the Rust API for the updater.
 
 use std::fmt::{Display, Formatter};
+use std::fs;
+use std::io::{Cursor, Read, Seek};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
 
 use crate::cache::{PatchInfo, UpdaterState};
 use crate::config::{set_config, with_config, ResolvedConfig};
 use crate::logging::init_logging;
 use crate::network::{download_to_path, send_patch_check_request};
 use crate::yaml::YamlConfig;
-use std::fs;
-use std::io::{Cursor, Read, Seek};
-use std::path::{Path, PathBuf};
 
 // https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests
 #[cfg(test)]
@@ -22,8 +24,6 @@ pub use crate::config::testing_reset_config;
 pub use crate::network::{
     testing_set_network_hooks, DownloadFileFn, Patch, PatchCheckRequest, PatchCheckRequestFn,
 };
-
-use anyhow::Context;
 
 pub enum UpdateStatus {
     NoUpdate,
@@ -51,6 +51,7 @@ pub enum UpdateError {
     InvalidState(String),
     BadServerResponse,
     FailedToSaveState,
+    ConfigNotInitialized,
 }
 
 impl std::error::Error for UpdateError {}
@@ -64,6 +65,7 @@ impl Display for UpdateError {
             UpdateError::InvalidState(msg) => write!(f, "Invalid State: {}", msg),
             UpdateError::FailedToSaveState => write!(f, "Failed to save state"),
             UpdateError::BadServerResponse => write!(f, "Bad server response"),
+            UpdateError::ConfigNotInitialized => write!(f, "Config not initialized"),
         }
     }
 }
@@ -89,26 +91,24 @@ pub fn init(app_config: AppConfig, yaml: &str) -> Result<(), UpdateError> {
     set_config(app_config, config).map_err(|err| UpdateError::InvalidState(err.to_string()))
 }
 
-fn check_for_update_internal(config: &ResolvedConfig) -> bool {
-    // Load UpdaterState from disk
-    // If there is no state, make an empty state.
-    let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
-    // Send info from app + current slot to server.
-    let response_result = send_patch_check_request(&config, &state);
-    match response_result {
-        Err(err) => {
-            error!("Failed update check: {err}");
-            return false;
-        }
-        Ok(response) => {
-            return response.patch_available;
-        }
-    }
-}
-
 /// Synchronously checks for an update and returns true if an update is available.
-pub fn check_for_update() -> bool {
-    return with_config(check_for_update_internal);
+pub fn check_for_update() -> anyhow::Result<bool> {
+    with_config(|config| {
+        // Load UpdaterState from disk
+        // If there is no state, make an empty state.
+        let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
+        // Send info from app + current slot to server.
+        let response_result = send_patch_check_request(&config, &state);
+        match response_result {
+            Err(err) => {
+                error!("Failed update check: {err}");
+                return false;
+            }
+            Ok(response) => {
+                return response.patch_available;
+            }
+        }
+    })
 }
 
 fn check_hash(path: &Path, expected_string: &str) -> anyhow::Result<bool> {
@@ -396,21 +396,21 @@ where
 /// The patch which will be run on next boot (which may still be the same
 /// as the current boot).
 /// This may be changed any time update() or start_update_thread() are called.
-pub fn next_boot_patch() -> Option<PatchInfo> {
-    return with_config(|config| {
+pub fn next_boot_patch() -> anyhow::Result<Option<PatchInfo>> {
+    with_config(|config| {
         let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
         return state.next_boot_patch();
-    });
+    })
 }
 
 /// The patch which is currently booted.  This is None until
 /// report_launch_start() is called at which point it is copied from
 /// next_boot_patch.
-pub fn current_boot_patch() -> Option<PatchInfo> {
-    return with_config(|config| {
+pub fn current_boot_patch() -> anyhow::Result<Option<PatchInfo>> {
+    with_config(|config| {
         let state = UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
         return state.current_boot_patch();
-    });
+    })
 }
 
 pub fn report_launch_start() -> anyhow::Result<()> {
@@ -421,41 +421,51 @@ pub fn report_launch_start() -> anyhow::Result<()> {
         // Make that patch the "booted" patch.
         state.activate_current_patch()?;
         state.save()
-    })
+    })?
 }
 
 /// Report that the current active path failed to launch.
 /// This will mark the patch as bad and activate the next best patch.
-pub fn report_launch_failure() -> Result<(), UpdateError> {
+pub fn report_launch_failure() -> anyhow::Result<()> {
     info!("Reporting failed launch.");
     with_config(|config| {
         let mut state =
             UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
 
-        let patch = state
-            .current_boot_patch()
-            .ok_or(UpdateError::InvalidState("No current patch".to_string()))?;
+        let patch =
+            state
+                .current_boot_patch()
+                .ok_or(anyhow::Error::from(UpdateError::InvalidState(
+                    "No current patch".to_string(),
+                )))?;
         state.mark_patch_as_bad(&patch);
-        state.activate_latest_bootable_patch()
-    })
+        state
+            .activate_latest_bootable_patch()
+            .map_err(|err| anyhow::Error::from(err))
+    })?
 }
 
-pub fn report_launch_success() -> Result<(), UpdateError> {
+pub fn report_launch_success() -> anyhow::Result<()> {
     with_config(|config| {
         let mut state =
             UpdaterState::load_or_new_on_error(&config.cache_dir, &config.release_version);
 
-        let patch = state
-            .current_boot_patch()
-            .ok_or(UpdateError::InvalidState("No current patch".to_string()))?;
+        let patch =
+            state
+                .current_boot_patch()
+                .ok_or(anyhow::Error::from(UpdateError::InvalidState(
+                    "No current patch".to_string(),
+                )))?;
         state.mark_patch_as_good(&patch);
-        state.save().map_err(|_| UpdateError::FailedToSaveState)
-    })
+        state
+            .save()
+            .map_err(|_| anyhow::Error::from(UpdateError::FailedToSaveState))
+    })?
 }
 
 /// Synchronously checks for an update and downloads and installs it if available.
-pub fn update() -> UpdateStatus {
-    return with_config(|config| {
+pub fn update() -> anyhow::Result<UpdateStatus> {
+    with_config(|config| {
         let result = update_internal(&config);
         match result {
             Err(err) => {
@@ -465,7 +475,7 @@ pub fn update() -> UpdateStatus {
             }
             Ok(status) => status,
         }
-    });
+    })
 }
 
 /// This does not return status.  The only output is the change to the saved
@@ -476,7 +486,7 @@ pub fn start_update_thread() {
     // call which is wrong. We should be able to release the lock during the
     // network requests.
     std::thread::spawn(move || {
-        let status = update();
+        let status = update().unwrap_or(UpdateStatus::UpdateHadError);
         info!("Update thread finished with status: {}", status);
     });
 }
@@ -526,17 +536,18 @@ mod tests {
                 })
                 .expect("move failed");
             state.save().expect("save failed");
-        });
-        assert!(crate::next_boot_patch().is_some());
+        })
+        .unwrap();
+        assert!(crate::next_boot_patch().unwrap().is_some());
         // pretend we booted from it
         crate::report_launch_start().unwrap();
         crate::report_launch_success().unwrap();
-        assert!(crate::next_boot_patch().is_some());
+        assert!(crate::next_boot_patch().unwrap().is_some());
         // mark it bad.
         crate::report_launch_failure().unwrap();
         // Technically might need to "reload"
         // ask for current patch (should get none).
-        assert!(crate::next_boot_patch().is_none());
+        assert!(crate::next_boot_patch().unwrap().is_none());
     }
 
     #[test]
@@ -597,16 +608,18 @@ mod tests {
         let tmp_dir = TempDir::new("example").unwrap();
         init_for_testing(&tmp_dir);
         assert_eq!(
-            crate::report_launch_failure(),
-            Err(crate::UpdateError::InvalidState(
-                "No current patch".to_string()
-            ))
+            crate::report_launch_failure()
+                .unwrap_err()
+                .downcast::<crate::UpdateError>()
+                .unwrap(),
+            crate::UpdateError::InvalidState("No current patch".to_string())
         );
         assert_eq!(
-            crate::report_launch_success(),
-            Err(crate::UpdateError::InvalidState(
-                "No current patch".to_string()
-            ))
+            crate::report_launch_success()
+                .unwrap_err()
+                .downcast::<crate::UpdateError>()
+                .unwrap(),
+            crate::UpdateError::InvalidState("No current patch".to_string())
         );
     }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/shorebirdtech/shorebird/issues/413

Validated by:
- Creating a new Flutter project
- Running `shorebird init`
- Removing `shorebird.yaml`
- Verifying that `shorebird --local-engine-src-path=$HOME/Shorebird/engine/src --local-engine=android_release_arm64 run -- --release` doesn't panic and still launches the app.

I also tested the release-patch flow to ensure that didn't break.

- Updates `with_config` in `library/src/config.rs` to
  - Return `anyhow::Result<R>` instead of `R`
  - Not panic if the config object isn't initialized
  - Return an error in the case where the config object isn't initialized
- Updates consumers of `with_config` to handle the possibility that `with_config` may return an error by propagating the error, usually to `log_on_error` in `library/src/c_api.rs` because the updater can't do much if no `shorebird.yaml` is provided.

## Potential Future Work

- Improve use of `anyhow::Error`
  - Wrapping our error types in `anyhow::Error::from()` is pretty verbose and I suspect there's a better, more idiomatic way to use `anyhow::Error`. The `report_launch_result_with_no_current_patch` test is especially ugly.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
