### PR TITLE
fix: remove more unwrap calls.

### DIFF
--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use crate::updater::AppConfig;
 use crate::yaml::YamlConfig;
 use crate::UpdateError;
+use anyhow::Context;
 
 #[cfg(not(test))]
 use once_cell::sync::OnceCell;
@@ -188,7 +189,10 @@ pub fn set_config(app_config: AppConfig, yaml: YamlConfig) -> anyhow::Result<()>
         config.cache_dir = app_config.cache_dir.to_string();
         let mut cache_path = std::path::PathBuf::from(app_config.cache_dir);
         cache_path.push("downloads");
-        config.download_dir = cache_path.to_str().unwrap().to_string();
+        config.download_dir = cache_path
+            .to_str()
+            .context("invalid cache path")?
+            .to_string();
         config.app_id = yaml.app_id.to_string();
         config.release_version = app_config.release_version.to_string();
         config.original_libapp_paths = app_config.original_libapp_paths;

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -310,7 +310,7 @@ pub fn report_launch_failure() -> anyhow::Result<()> {
                 .ok_or(anyhow::Error::from(UpdateError::InvalidState(
                     "No current patch".to_string(),
                 )))?;
-        state.mark_patch_as_bad(&patch);
+        state.mark_patch_as_bad(patch.number);
         state
             .activate_latest_bootable_patch()
             .map_err(|err| anyhow::Error::from(err))
@@ -328,7 +328,7 @@ pub fn report_launch_success() -> anyhow::Result<()> {
                 .ok_or(anyhow::Error::from(UpdateError::InvalidState(
                     "No current patch".to_string(),
                 )))?;
-        state.mark_patch_as_good(&patch);
+        state.mark_patch_as_good(patch.number);
         state
             .save()
             .map_err(|_| anyhow::Error::from(UpdateError::FailedToSaveState))


### PR DESCRIPTION
Each unwrap() is a potential crash.  Shorebird's updater code should never crash.

There still are a couple, but I think we should set up coverage first so we can track that we're testing all these changes.
