### PR TITLE
chore: use a usize instead of a char* for next boot patch number

### DIFF
--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -56,13 +56,14 @@ bool shorebird_init(const struct AppParameters *c_params,
                     const char *c_yaml);
 
 /**
- * Return the active patch number, or NULL if there is no active patch.
+ * The patch number that will boot on the next run of the app, or 0 if there is
+ * no next patch.
  */
-SHOREBIRD_EXPORT char *shorebird_next_boot_patch_number(void);
+SHOREBIRD_EXPORT uintptr_t shorebird_next_boot_patch_number(void);
 
 /**
- * Return the path to the active patch for the app, or NULL if there is no
- * active patch.
+ * The path to the patch that will boot on the next run of the app, or NULL if
+ * there is no next patch.
  */
 SHOREBIRD_EXPORT char *shorebird_next_boot_patch_path(void);
 

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -116,21 +116,19 @@ pub extern "C" fn shorebird_init(
     )
 }
 
-/// Return the active patch number, or NULL if there is no active patch.
+/// The patch number that will boot on the next run of the app, or 0 if there is
+/// no next patch.
 #[no_mangle]
-pub extern "C" fn shorebird_next_boot_patch_number() -> *mut c_char {
+pub extern "C" fn shorebird_next_boot_patch_number() -> usize {
     log_on_error(
-        || {
-            let maybe_patch_number = updater::next_boot_patch()?.map(|p| p.number.to_string());
-            to_c_string(maybe_patch_number)
-        },
+        || Ok(updater::next_boot_patch()?.map(|p| p.number).unwrap_or(0)),
         "fetching next_boot_patch_number",
-        std::ptr::null_mut(),
+        0,
     )
 }
 
-/// Return the path to the active patch for the app, or NULL if there is no
-/// active patch.
+/// The path to the patch that will boot on the next run of the app, or NULL if
+/// there is no next patch.
 #[no_mangle]
 pub extern "C" fn shorebird_next_boot_patch_path() -> *mut c_char {
     log_on_error(
@@ -323,9 +321,9 @@ mod test {
         free_c_string(c_yaml);
         free_parameters(c_params);
 
-        // Number and path are empty (but do not crash) when we have an
+        // Number is 0 and path is empty (but do not crash) when we have an
         // empty cache and update has not been called.
-        assert_eq!(shorebird_next_boot_patch_number(), null_mut());
+        assert_eq!(shorebird_next_boot_patch_number(), 0);
         assert_eq!(shorebird_next_boot_patch_path(), null_mut());
 
         // Similarly we can report launches with no patch without crashing.
@@ -389,8 +387,8 @@ mod test {
         );
         shorebird_update();
 
-        let version = to_rust(shorebird_next_boot_patch_number()).unwrap();
-        assert!(version.eq("1"));
+        let version = shorebird_next_boot_patch_number();
+        assert_eq!(version, 1);
 
         // Read path contents into memory and check against expected.
         let path = to_rust(shorebird_next_boot_patch_path()).unwrap();


### PR DESCRIPTION
## Description

Passes the next patch number back as a `usize` instead of a `char *`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
