### PR TITLE
feat: add shorebird_current_boot_patch_number function

### DIFF
--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -56,6 +56,12 @@ bool shorebird_init(const struct AppParameters *c_params,
                     const char *c_yaml);
 
 /**
+ * The currently running patch number, or 0 if the release has not been
+ * patched.
+ */
+SHOREBIRD_EXPORT uintptr_t shorebird_current_boot_patch_number(void);
+
+/**
  * The patch number that will boot on the next run of the app, or 0 if there is
  * no next patch.
  */
@@ -89,8 +95,9 @@ SHOREBIRD_EXPORT void shorebird_start_update_thread(void);
 
 /**
  * Tell the updater that we're launching from what it told us was the
- * next patch to boot from.  This will copy the next_boot patch to be
- * the current_boot patch.
+ * next patch to boot from. This will copy the next_boot patch to be the
+ * current_boot patch.
+ *
  * It is required to call this function before calling
  * shorebird_report_launch_success or shorebird_report_launch_failure.
  */
@@ -108,6 +115,7 @@ SHOREBIRD_EXPORT void shorebird_report_launch_failure(void);
  * as having been launched successfully.  We don't currently do anything
  * with this information, but it could be used to record a point at which
  * we will not roll back from.
+ *
  * This is not currently wired up to be called from the Engine.  It's unclear
  * where best to connect it.  Expo waits 5 seconds after the app launches
  * and then marks the launch as successful.  We could do something similar.

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -116,6 +116,21 @@ pub extern "C" fn shorebird_init(
     )
 }
 
+/// The currently running patch number, or 0 if the release has not been
+/// patched.
+#[no_mangle]
+pub extern "C" fn shorebird_current_boot_patch_number() -> usize {
+    log_on_error(
+        || {
+            Ok(updater::current_boot_patch()?
+                .map(|p| p.number)
+                .unwrap_or(0))
+        },
+        "fetching next_boot_patch_number",
+        0,
+    )
+}
+
 /// The patch number that will boot on the next run of the app, or 0 if there is
 /// no next patch.
 #[no_mangle]
@@ -175,8 +190,9 @@ pub extern "C" fn shorebird_start_update_thread() {
 }
 
 /// Tell the updater that we're launching from what it told us was the
-/// next patch to boot from.  This will copy the next_boot patch to be
-/// the current_boot patch.
+/// next patch to boot from. This will copy the next_boot patch to be the
+/// current_boot patch.
+///
 /// It is required to call this function before calling
 /// shorebird_report_launch_success or shorebird_report_launch_failure.
 #[no_mangle]
@@ -200,6 +216,7 @@ pub extern "C" fn shorebird_report_launch_failure() {
 /// as having been launched successfully.  We don't currently do anything
 /// with this information, but it could be used to record a point at which
 /// we will not roll back from.
+///
 /// This is not currently wired up to be called from the Engine.  It's unclear
 /// where best to connect it.  Expo waits 5 seconds after the app launches
 /// and then marks the launch as successful.  We could do something similar.

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -40,8 +40,8 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    _shorebirdCodePush.currentPatchVersion().then((currentPatchVersion) async {
-      final nextPatchVersion = await _shorebirdCodePush.nextPatchVersion();
+    _shorebirdCodePush.currentPatchNumber().then((currentPatchVersion) async {
+      final nextPatchVersion = await _shorebirdCodePush.nextPatchNumber();
 
       if (!mounted) return;
 

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -32,7 +32,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  final ShorebirdCodePush _shorebirdCodePush = ShorebirdCodePush();
+  final _shorebirdCodePush = ShorebirdCodePush();
   int? _patchVersion;
   bool _isCheckingForUpdate = false;
 

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -33,17 +33,21 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   final _shorebirdCodePush = ShorebirdCodePush();
-  int? _patchVersion;
+  int? _currentPatchVersion;
+  int? _nextPatchVersion;
   bool _isCheckingForUpdate = false;
 
   @override
   void initState() {
     super.initState();
-    _shorebirdCodePush.currentPatchVersion().then((version) {
+    _shorebirdCodePush.currentPatchVersion().then((currentPatchVersion) async {
+      final nextPatchVersion = await _shorebirdCodePush.nextPatchVersion();
+
       if (!mounted) return;
 
       setState(() {
-        _patchVersion = version;
+        _currentPatchVersion = currentPatchVersion;
+        _nextPatchVersion = nextPatchVersion;
       });
     });
   }
@@ -83,9 +87,24 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             const Text('Current patch version:'),
             Text(
-              _patchVersion != null ? _patchVersion.toString() : 'none',
+              _currentPatchVersion != null
+                  ? _currentPatchVersion.toString()
+                  : 'none',
               style: Theme.of(context).textTheme.headlineMedium,
             ),
+            if (_nextPatchVersion != null &&
+                _nextPatchVersion != _currentPatchVersion)
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 10),
+                  const Text('Next patch version:'),
+                  Text(
+                    _nextPatchVersion.toString(),
+                    style: Theme.of(context).textTheme.headlineMedium,
+                  ),
+                ],
+              ),
             const SizedBox(
               height: 20,
             ),

--- a/shorebird_code_push/example/pubspec.yaml
+++ b/shorebird_code_push/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: shorebird_code_push_example
 description: An example demonstrating how to use the shorebird_code_push package
 publish_to: 'none'
 
-version: 1.0.0+16
+version: 1.0.0+17
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/shorebird_code_push/example/pubspec.yaml
+++ b/shorebird_code_push/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: shorebird_code_push_example
 description: An example demonstrating how to use the shorebird_code_push package
 publish_to: 'none'
 
-version: 1.0.0+15
+version: 1.0.0+16
 
 environment:
   sdk: '>=3.0.5 <4.0.0'

--- a/shorebird_code_push/lib/src/generated/updater_bindings.g.dart
+++ b/shorebird_code_push/lib/src/generated/updater_bindings.g.dart
@@ -2086,6 +2086,18 @@ class UpdaterBindings {
 
   /// The patch number that will boot on the next run of the app, or 0 if there is
   /// no next patch.
+  int shorebird_currnet_boot_patch_number() {
+    return _shorebird_currnet_boot_patch_number();
+  }
+
+  late final _shorebird_currnet_boot_patch_numberPtr =
+      _lookup<ffi.NativeFunction<ffi.UintPtr Function()>>(
+          'shorebird_currnet_boot_patch_number');
+  late final _shorebird_currnet_boot_patch_number =
+      _shorebird_currnet_boot_patch_numberPtr.asFunction<int Function()>();
+
+  /// The patch number that will boot on the next run of the app, or 0 if there is
+  /// no next patch.
   int shorebird_next_boot_patch_number() {
     return _shorebird_next_boot_patch_number();
   }

--- a/shorebird_code_push/lib/src/generated/updater_bindings.g.dart
+++ b/shorebird_code_push/lib/src/generated/updater_bindings.g.dart
@@ -2084,17 +2084,17 @@ class UpdaterBindings {
   late final _shorebird_init = _shorebird_initPtr.asFunction<
       bool Function(ffi.Pointer<AppParameters>, ffi.Pointer<ffi.Char>)>();
 
-  /// The patch number that will boot on the next run of the app, or 0 if there is
-  /// no next patch.
-  int shorebird_currnet_boot_patch_number() {
-    return _shorebird_currnet_boot_patch_number();
+  /// The currently running patch number, or 0 if the release has not been
+  /// patched.
+  int shorebird_current_boot_patch_number() {
+    return _shorebird_current_boot_patch_number();
   }
 
-  late final _shorebird_currnet_boot_patch_numberPtr =
+  late final _shorebird_current_boot_patch_numberPtr =
       _lookup<ffi.NativeFunction<ffi.UintPtr Function()>>(
-          'shorebird_currnet_boot_patch_number');
-  late final _shorebird_currnet_boot_patch_number =
-      _shorebird_currnet_boot_patch_numberPtr.asFunction<int Function()>();
+          'shorebird_current_boot_patch_number');
+  late final _shorebird_current_boot_patch_number =
+      _shorebird_current_boot_patch_numberPtr.asFunction<int Function()>();
 
   /// The patch number that will boot on the next run of the app, or 0 if there is
   /// no next patch.
@@ -2169,8 +2169,9 @@ class UpdaterBindings {
       _shorebird_start_update_threadPtr.asFunction<void Function()>();
 
   /// Tell the updater that we're launching from what it told us was the
-  /// next patch to boot from.  This will copy the next_boot patch to be
-  /// the current_boot patch.
+  /// next patch to boot from. This will copy the next_boot patch to be the
+  /// current_boot patch.
+  ///
   /// It is required to call this function before calling
   /// shorebird_report_launch_success or shorebird_report_launch_failure.
   void shorebird_report_launch_start() {
@@ -2200,6 +2201,7 @@ class UpdaterBindings {
   /// as having been launched successfully.  We don't currently do anything
   /// with this information, but it could be used to record a point at which
   /// we will not roll back from.
+  ///
   /// This is not currently wired up to be called from the Engine.  It's unclear
   /// where best to connect it.  Expo waits 5 seconds after the app launches
   /// and then marks the launch as successful.  We could do something similar.

--- a/shorebird_code_push/lib/src/shorebird_code_push.dart
+++ b/shorebird_code_push/lib/src/shorebird_code_push.dart
@@ -22,15 +22,21 @@ class ShorebirdCodePush {
 
   /// The version of the currently-installed patch. Null if no patch is
   /// installed (i.e., the app is running the release version).
-  Future<int?> currentPatchVersion() {
-    return _runInIsolate((updater) => updater.currentPatchNumber());
+  Future<int?> currentPatchNumber() {
+    return _runInIsolate((updater) {
+      final patchNumber = updater.currentPatchNumber();
+      return patchNumber == 0 ? null : patchNumber;
+    });
   }
 
   /// The version of the patch that will be run on the next app launch. If no
   /// new patch has been downloaded, this will be the same as
-  /// [currentPatchVersion].
-  Future<int?> nextPatchVersion() {
-    return _runInIsolate((updater) => updater.nextPatchNumber());
+  /// [currentPatchNumber].
+  Future<int?> nextPatchNumber() {
+    return _runInIsolate((updater) {
+      final patchNumber = updater.nextPatchNumber();
+      return patchNumber == 0 ? null : patchNumber;
+    });
   }
 
   /// Creates an [Updater] in a separate isolate and runs the given function.

--- a/shorebird_code_push/lib/src/shorebird_code_push.dart
+++ b/shorebird_code_push/lib/src/shorebird_code_push.dart
@@ -26,6 +26,13 @@ class ShorebirdCodePush {
     return _runInIsolate((updater) => updater.currentPatchNumber());
   }
 
+  /// The version of the patch that will be run on the next app launch. If no
+  /// new patch has been downloaded, this will be the same as
+  /// [currentPatchVersion].
+  Future<int?> nextPatchVersion() {
+    return _runInIsolate((updater) => updater.nextPatchNumber());
+  }
+
   /// Creates an [Updater] in a separate isolate and runs the given function.
   Future<T> _runInIsolate<T>(T Function(Updater updater) f) async {
     return Isolate.run(() {

--- a/shorebird_code_push/lib/src/updater.dart
+++ b/shorebird_code_push/lib/src/updater.dart
@@ -22,7 +22,7 @@ class Updater {
   // available. It should instead always return the current patch version.
   int currentPatchNumber() {
     try {
-      return bindings.shorebird_next_boot_patch_number();
+      return bindings.shorebird_current_boot_patch_number();
     } catch (e) {
       return 0;
     }

--- a/shorebird_code_push/lib/src/updater.dart
+++ b/shorebird_code_push/lib/src/updater.dart
@@ -18,8 +18,6 @@ class Updater {
   static late UpdaterBindings bindings;
 
   /// The currently active patch number.
-  // TODO(bryanoltman): this will return the current number + 1 if an update is
-  // available. It should instead always return the current patch version.
   int currentPatchNumber() {
     try {
       return bindings.shorebird_current_boot_patch_number();
@@ -34,6 +32,16 @@ class Updater {
       return bindings.shorebird_check_for_update();
     } catch (e) {
       return false;
+    }
+  }
+
+  /// The next patch number that will be loaded. Will be the same as
+  /// currentPatchNumber if no new patch is available.
+  int nextPatchNumber() {
+    try {
+      return bindings.shorebird_next_boot_patch_number();
+    } catch (e) {
+      return 0;
     }
   }
 }

--- a/shorebird_code_push/test/src/shorebird_code_push_test.dart
+++ b/shorebird_code_push/test/src/shorebird_code_push_test.dart
@@ -32,9 +32,26 @@ void main() {
     });
 
     group('currentPatchNumber', () {
+      test('returns null if current patch is reported as 0', () async {
+        when(() => updater.currentPatchNumber()).thenReturn(0);
+        expect(await shorebirdCodePush.currentPatchNumber(), isNull);
+      });
+
       test('forwards the return value of updater.currentPatchNumber', () async {
         when(() => updater.currentPatchNumber()).thenReturn(1);
-        expect(await shorebirdCodePush.currentPatchVersion(), 1);
+        expect(await shorebirdCodePush.currentPatchNumber(), 1);
+      });
+    });
+
+    group('nextPatchNumber', () {
+      test('returns null if current patch is reported as 0', () async {
+        when(() => updater.nextPatchNumber()).thenReturn(0);
+        expect(await shorebirdCodePush.nextPatchNumber(), isNull);
+      });
+
+      test('forwards the return value of updater.nextPatchNumber', () async {
+        when(() => updater.nextPatchNumber()).thenReturn(1);
+        expect(await shorebirdCodePush.nextPatchNumber(), 1);
       });
     });
   });

--- a/shorebird_code_push/test/src/updater_test.dart
+++ b/shorebird_code_push/test/src/updater_test.dart
@@ -23,13 +23,13 @@ void main() {
 
     group('currentPatchNumber', () {
       test('returns 0 if shorebird_next_boot_patch_number throws', () {
-        when(() => updaterBindings.shorebird_next_boot_patch_number())
+        when(() => updaterBindings.shorebird_current_boot_patch_number())
             .thenThrow(Exception());
         expect(updater.currentPatchNumber(), 0);
       });
 
       test('forwards the result of shorebird_next_boot_patch_number', () {
-        when(() => updaterBindings.shorebird_next_boot_patch_number())
+        when(() => updaterBindings.shorebird_current_boot_patch_number())
             .thenReturn(123);
         final currentPatchNumber = updater.currentPatchNumber();
         expect(currentPatchNumber, 123);
@@ -51,6 +51,21 @@ void main() {
         when(() => updaterBindings.shorebird_check_for_update())
             .thenReturn(false);
         expect(updater.checkForUpdate(), isFalse);
+      });
+    });
+
+    group('nextPatchNumber', () {
+      test('returns 0 if shorebird_next_boot_patch_number throws', () {
+        when(() => updaterBindings.shorebird_next_boot_patch_number())
+            .thenThrow(Exception());
+        expect(updater.nextPatchNumber(), 0);
+      });
+
+      test('forwards the result of shorebird_next_boot_patch_number', () {
+        when(() => updaterBindings.shorebird_next_boot_patch_number())
+            .thenReturn(123);
+        final currentPatchNumber = updater.nextPatchNumber();
+        expect(currentPatchNumber, 123);
       });
     });
   });


### PR DESCRIPTION
## Description

Adds `shorebird_current_boot_patch_number` to the Updater api, updates the example to use it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
