### PR TITLE
fix: glibc error when patching on Linux

### DIFF
--- a/.github/workflows/build_patch_artifacts.yaml
+++ b/.github/workflows/build_patch_artifacts.yaml
@@ -11,7 +11,7 @@ jobs:
   upload-artifacts:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_patch_artifacts.yaml
+++ b/.github/workflows/build_patch_artifacts.yaml
@@ -11,7 +11,11 @@ jobs:
   upload-artifacts:
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
 
     runs-on: ${{ matrix.os }}
 
@@ -22,6 +26,7 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: "patch"
+          target: ${{ matrix.target }}
           tar: none
           zip: all
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Fixes #47 

This PR downgrades the version of the GitHub Actions Ubuntu machine. The machine will use an older version of glibc to build `patch` which will fix the error users are facing.

I have tested this change on an Ubuntu 20.04 VM.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
