### PR TITLE
feat: add support for parsing update_behavior from shorebird.yaml

### DIFF
--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -14,6 +14,12 @@
 #endif
 
 
+typedef enum UpdateBehavior {
+  BackgroundOnLaunch,
+  Manual,
+  WaitOnLaunch,
+} UpdateBehavior;
+
 /**
  * Struct containing configuration parameters for the updater.
  * Passed to all updater functions.
@@ -54,6 +60,8 @@ extern "C" {
 SHOREBIRD_EXPORT
 bool shorebird_init(const struct AppParameters *c_params,
                     const char *c_yaml);
+
+SHOREBIRD_EXPORT enum UpdateBehavior shorebird_update_behavior(void);
 
 /**
  * The currently running patch number, or 0 if the release has not been

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -109,6 +109,37 @@ pub extern "C" fn shorebird_init(
     )
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum UpdateBehavior {
+    BackgroundOnLaunch,
+    Manual,
+    WaitOnLaunch,
+}
+
+impl UpdateBehavior {
+    pub fn from_string(s: Option<String>) -> anyhow::Result<Self> {
+        match s {
+            Some(s) => match s.as_str() {
+                "background" => Ok(UpdateBehavior::BackgroundOnLaunch),
+                "manual" => Ok(UpdateBehavior::Manual),
+                "wait" => Ok(UpdateBehavior::WaitOnLaunch),
+                _ => anyhow::bail!("Unknown update behavior: {}", s),
+            },
+            None => Ok(UpdateBehavior::BackgroundOnLaunch),
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn shorebird_update_behavior() -> UpdateBehavior {
+    log_on_error(
+        || updater::update_behavior(),
+        "fetching update behavior",
+        UpdateBehavior::BackgroundOnLaunch,
+    )
+}
+
 /// The currently running patch number, or 0 if the release has not been
 /// patched.
 #[no_mangle]
@@ -334,6 +365,51 @@ mod test {
         assert_eq!(shorebird_init(&c_params, c_yaml), false);
         free_c_string(c_yaml);
         free_parameters(c_params);
+    }
+
+    #[serial]
+    #[test]
+    fn yaml_parsing() {
+        testing_reset_config();
+        let tmp_dir = TempDir::new("example").unwrap();
+        let c_params = parameters(&tmp_dir, "/dir/lib/arm64/libapp.so");
+        let c_yaml = c_string(
+            "
+        app_id: foo
+        channel: bar
+        base_url: baz
+        update_behavior: manual",
+        );
+        assert_eq!(shorebird_init(&c_params, c_yaml), true);
+        free_c_string(c_yaml);
+        free_parameters(c_params);
+        assert_eq!(shorebird_update_behavior(), UpdateBehavior::Manual);
+    }
+
+    #[test]
+    fn update_behavior_from_string() {
+        assert_eq!(
+            UpdateBehavior::from_string(Some("background".to_owned())).unwrap(),
+            UpdateBehavior::BackgroundOnLaunch
+        );
+        assert_eq!(
+            UpdateBehavior::from_string(Some("manual".to_owned())).unwrap(),
+            UpdateBehavior::Manual
+        );
+        assert_eq!(
+            UpdateBehavior::from_string(Some("wait".to_owned())).unwrap(),
+            UpdateBehavior::WaitOnLaunch
+        );
+        assert_eq!(
+            UpdateBehavior::from_string(Some("foo".to_owned()))
+                .unwrap_err()
+                .to_string(),
+            "Unknown update behavior: foo"
+        );
+        assert_eq!(
+            UpdateBehavior::from_string(None).unwrap(),
+            UpdateBehavior::BackgroundOnLaunch
+        );
     }
 
     #[serial]

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -1,6 +1,7 @@
 // This file handles the global config for the updater library.
 use crate::network::NetworkHooks;
 
+use crate::c_api::UpdateBehavior;
 use crate::updater::AppConfig;
 use crate::yaml::YamlConfig;
 use crate::UpdateError;
@@ -73,6 +74,7 @@ where
 pub struct UpdateConfig {
     pub cache_dir: PathBuf,
     pub download_dir: PathBuf,
+    pub update_behavior: UpdateBehavior,
     pub channel: String,
     pub app_id: String,
     pub release_version: String,
@@ -102,6 +104,7 @@ pub fn set_config(
                 .as_deref()
                 .unwrap_or(DEFAULT_CHANNEL)
                 .to_owned(),
+            update_behavior: UpdateBehavior::from_string(yaml.update_behavior)?,
             app_id: yaml.app_id.to_string(),
             release_version: app_config.release_version.to_string(),
             libapp_path,

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use anyhow::bail;
 use anyhow::Context;
 
+use crate::c_api::UpdateBehavior;
 use crate::cache::{PatchInfo, UpdaterState};
 use crate::config::{set_config, with_config, UpdateConfig};
 use crate::logging::init_logging;
@@ -115,6 +116,10 @@ pub fn init(app_config: AppConfig, yaml: &str) -> Result<(), UpdateError> {
     debug!("libapp_path: {:?}", libapp_path);
     set_config(app_config, libapp_path, config, NetworkHooks::default())
         .map_err(|err| UpdateError::InvalidState(err.to_string()))
+}
+
+pub fn update_behavior() -> anyhow::Result<UpdateBehavior> {
+    with_config(|config| Ok(config.update_behavior))
 }
 
 fn check_for_update_internal() -> anyhow::Result<PatchCheckResponse> {

--- a/library/src/yaml.rs
+++ b/library/src/yaml.rs
@@ -10,6 +10,8 @@ pub struct YamlConfig {
     pub channel: Option<String>,
     /// Update URL.  Defaults to the default update URL if not set.
     pub base_url: Option<String>,
+    /// Update behavior.  Defaults to "background" if not set.
+    pub update_behavior: Option<String>,
 }
 
 impl YamlConfig {


### PR DESCRIPTION
The actual support will be in the C++ engine, but this keeps
all yaml parsing in the Rust code for simplicity.
