### PR TITLE
fix: log more friendly error message in case of no internet connection

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -24,6 +24,8 @@ comde = { version = "0.2.3", default-features = false, features = [
 ] }
 # For decoding the hex-encoded hashes in Patch network responses.
 hex = "0.4.3"
+# Used to construct mock responses.
+http = "0.2.9"
 libc = "0.2.98"
 # For error!(), info!(), etc macros. `print` will not show up on Android.
 log = "0.4.14"

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -21,7 +21,7 @@ fn patches_check_url(base_url: &str) -> String {
 pub type PatchCheckRequestFn = fn(&str, PatchCheckRequest) -> anyhow::Result<PatchCheckResponse>;
 pub type DownloadFileFn = fn(&str) -> anyhow::Result<Vec<u8>>;
 
-/// A container for network clalbacks which can be mocked out for testing.
+/// A container for network callbacks which can be mocked out for testing.
 #[derive(Clone)]
 pub struct NetworkHooks {
     /// The function to call to send a patch check request.


### PR DESCRIPTION
## Description

Inspects the error message produced by our patch check request to see if it matches what we expect in cases of no internet connection. If so, log "Patch check request failed due to network error. Please check your internet connection".

Fixes https://github.com/shorebirdtech/shorebird/issues/759

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
