### PR TITLE
refactor: move model structs and tests into models.rs

### DIFF
--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -243,7 +243,9 @@ pub extern "C" fn shorebird_report_launch_success() {
 mod test {
     use super::*;
     use crate::{
-        network::PatchCheckResponse, testing_set_network_hooks, updater::testing_reset_config,
+        models::{Patch, PatchCheckResponse},
+        testing_set_network_hooks,
+        updater::testing_reset_config,
     };
     use serial_test::serial;
     use tempdir::TempDir;
@@ -427,7 +429,7 @@ mod test {
                 let hash = "bb8f1d041a5cdc259055afe9617136799543e0a7a86f86db82f8c1fadbd8cc45";
                 Ok(PatchCheckResponse {
                     patch_available: true,
-                    patch: Some(crate::Patch {
+                    patch: Some(Patch {
                         number: 1,
                         hash: hash.to_owned(),
                         download_url: "ignored".to_owned(),
@@ -525,7 +527,7 @@ mod test {
                 let _lock = CALLBACK_MUTEX.lock().unwrap();
                 Ok(PatchCheckResponse {
                     patch_available: false,
-                    patch: Some(crate::Patch {
+                    patch: Some(Patch {
                         number: 1,
                         hash: "ignored".to_owned(),
                         download_url: "ignored".to_owned(),

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -9,6 +9,7 @@ pub mod c_api;
 mod cache;
 mod config;
 mod logging;
+mod models;
 mod network;
 mod updater;
 mod updater_lock;

--- a/library/src/models.rs
+++ b/library/src/models.rs
@@ -1,0 +1,85 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct Patch {
+    /// The patch number.  Starts at 1 for each new release and increases
+    /// monotonically.
+    pub number: usize,
+    /// The hex-encoded sha256 hash of the final uncompressed patch file.
+    /// Legacy: originally "#" before we implemented hash checks (remove).
+    pub hash: String,
+    /// The URL to download the patch file from.
+    pub download_url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PatchCheckRequest {
+    /// The Shorebird app_id built into the shorebird.yaml in the app.
+    pub app_id: String,
+    /// The Shorebird channel built into the shorebird.yaml in the app.
+    pub channel: String,
+    /// The release version from AndroidManifest.xml, Info.plist in the app.
+    pub release_version: String,
+    /// The latest patch number that the client has downloaded.
+    /// Not necessarily the one it's running (if some have been marked bad).
+    /// We could rename this to be more clear.    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch_number: Option<usize>,
+    /// Platform (e.g. "android", "ios", "windows", "macos", "linux").
+    pub platform: String,
+    /// Architecture we're running (e.g. "aarch64", "x86", "x86_64").
+    pub arch: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PatchCheckResponse {
+    pub patch_available: bool,
+    #[serde(default)]
+    pub patch: Option<Patch>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PatchCheckRequest, PatchCheckResponse};
+
+    #[test]
+    fn check_patch_request_serialization() {
+        let request = PatchCheckRequest {
+            app_id: "com.example.app".to_string(),
+            channel: "stable".to_string(),
+            release_version: "1.0.0".to_string(),
+            patch_number: Some(1),
+            platform: "android".to_string(),
+            arch: "aarch64".to_string(),
+        };
+
+        let serialized = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            serialized,
+            r###"{"app_id":"com.example.app","channel":"stable","release_version":"1.0.0","patch_number":1,"platform":"android","arch":"aarch64"}"###
+        )
+    }
+
+    #[test]
+    fn check_patch_response_deserialization() {
+        let data = r###"
+    {
+        "patch_available": true,
+        "patch": {
+            "number": 1,
+            "download_url": "https://storage.googleapis.com/patch_artifacts/17a28ec1-00cf-452d-bdf9-dbb9acb78600/dlc.vmcode",
+            "hash": "#"
+        }
+    }"###;
+
+        let response: PatchCheckResponse = serde_json::from_str(data).unwrap();
+
+        assert!(response.patch_available == true);
+        assert!(response.patch.is_some());
+
+        let patch = response.patch.unwrap();
+        assert_eq!(patch.number, 1);
+        assert_eq!(patch.download_url, "https://storage.googleapis.com/patch_artifacts/17a28ec1-00cf-452d-bdf9-dbb9acb78600/dlc.vmcode");
+        assert_eq!(patch.hash, "#");
+    }
+}

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -21,7 +21,7 @@ fn patches_check_url(base_url: &str) -> String {
 pub type PatchCheckRequestFn = fn(&str, PatchCheckRequest) -> anyhow::Result<PatchCheckResponse>;
 pub type DownloadFileFn = fn(&str) -> anyhow::Result<Vec<u8>>;
 
-/// A container for network clalbacks which can be mocked out for testing.
+/// A container for network callbacks which can be mocked out for testing.
 #[derive(Clone)]
 pub struct NetworkHooks {
     /// The function to call to send a patch check request.

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -12,9 +12,8 @@ use anyhow::Context;
 use crate::cache::{PatchInfo, UpdaterState};
 use crate::config::{set_config, with_config, UpdateConfig};
 use crate::logging::init_logging;
-use crate::network::{
-    download_to_path, send_patch_check_request, NetworkHooks, PatchCheckResponse,
-};
+use crate::models::PatchCheckResponse;
+use crate::network::{download_to_path, send_patch_check_request, NetworkHooks};
 use crate::updater_lock::{with_updater_thread_lock, UpdaterLockState};
 use crate::yaml::YamlConfig;
 
@@ -26,9 +25,7 @@ use std::{println as info, println as error, println as debug}; // Workaround to
 // Expose testing_reset_config for integration tests.
 pub use crate::config::testing_reset_config;
 #[cfg(test)]
-pub use crate::network::{
-    testing_set_network_hooks, DownloadFileFn, Patch, PatchCheckRequest, PatchCheckRequestFn,
-};
+pub use crate::network::{testing_set_network_hooks, DownloadFileFn, PatchCheckRequestFn};
 
 pub enum UpdateStatus {
     NoUpdate,


### PR DESCRIPTION
## Description

Splits model definitions out of network.rs into their own file.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
