### PR TITLE
fix: don't regenerate client id if UpdaterState successfully loaded

### DIFF
--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -72,6 +72,7 @@ fn generate_client_id() -> String {
 }
 
 impl UpdaterState {
+    /// Creates a new UpdaterState. If client_id is None, a new one will be generated.
     fn new(cache_dir: PathBuf, release_version: String, client_id: Option<String>) -> Self {
         Self {
             cache_dir,


### PR DESCRIPTION
## Description

Fixes issue where client_id was being regenerated when the app's release version changed or when the previous state failed to validate.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
