### PR TITLE
refactor: Prepare to have more than one event type

### DIFF
--- a/library/build.rs
+++ b/library/build.rs
@@ -2,12 +2,24 @@ extern crate cbindgen;
 
 use std::env;
 
-// See https://github.com/eqrion/cbindgen/blob/master/docs.md#buildrs
+// See:
+// https://github.com/eqrion/cbindgen/blob/master/docs.md#buildrs
+// https://doc.rust-lang.org/cargo/reference/build-scripts.html
+// https://doc.rust-lang.org/cargo/reference/build-script-examples.html
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
     // Should this write to the out dir (target) instead?
-    cbindgen::generate(crate_dir)
-        .expect("Unable to generate bindings")
-        .write_to_file("include/updater.h");
+    let result = cbindgen::generate(crate_dir);
+    match result {
+        Ok(contents) => {
+            contents.write_to_file("include/updater.h");
+        }
+        Err(e) => {
+            println!("cargo:warning=Error generating bindings: {}", e);
+            // If we were to exit 1 here we would stop local rust
+            // analysis from working. So we just print the error
+            // and continue.
+        }
+    }
 }

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -4,6 +4,12 @@
 // name collisions with other libraries.
 // cbindgen:prefix-with-name could do this for us.
 
+/// This file contains the C API for the updater library.
+/// It is intended to be used by language bindings, and is not intended to be
+/// used directly by Rust code.
+/// The C API is not stable and may change at any time.
+/// You can see usage of this API in Shorebird's Flutter engine:
+/// https://github.com/shorebirdtech/engine/blob/shorebird/dev/shell/common/shorebird.cc
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::PathBuf;

--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -1,0 +1,51 @@
+// This file's job is to deal with the update_server and network side
+// of the updater library.
+
+use serde::{Serialize, Serializer};
+
+#[derive(Debug)]
+pub enum EventType {
+    PatchInstallSuccess,
+    // PatchInstallFailure,
+}
+
+impl Serialize for EventType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(match self {
+            EventType::PatchInstallSuccess => "__patch_install__",
+            // EventType::PatchInstallFailure => "__patch_install_failure__",
+        })
+    }
+}
+
+/// Any edits to this struct should be made carefully and in accordance
+/// with our privacy policy:
+/// https://docs.shorebird.dev/privacy
+/// An event that is sent to the server when a patch is successfully installed.
+#[derive(Debug, Serialize)]
+pub struct PatchEvent {
+    /// The Shorebird app_id built into the shorebird.yaml in the app.
+    pub app_id: String,
+
+    /// The architecture we're running (e.g. "aarch64", "x86", "x86_64").
+    pub arch: String,
+
+    /// The unique ID of this device.
+    pub client_id: String,
+
+    /// The identifier of this event.
+    #[serde(rename = "type")]
+    pub identifier: EventType,
+
+    /// The patch number that was installed.
+    pub patch_number: usize,
+
+    /// The platform we're running on (e.g. "android", "ios", "windows", "macos", "linux").
+    pub platform: String,
+
+    /// The release version from AndroidManifest.xml, Info.plist in the app.
+    pub release_version: String,
+}

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -8,6 +8,7 @@ pub mod c_api;
 // Declare other .rs file/module exists, but make them private.
 mod cache;
 mod config;
+mod events;
 mod logging;
 mod network;
 mod updater;


### PR DESCRIPTION
Refactored our PatchInstallEvent to be just PatchEvent
and allow us to have more than one event type.

I moved it into its own events.rs file and added privacy
warnings to both this and the network code (eventually
we may move all this into a separate privacy.rs file).

I also fixed our build.rs file to not panic when our build
is otherwise broken. For whatever reason that seems to
cause the rust-analyzer to stop and not show any future
warnings (thus it's hard to fix things).

I moved away from having a "new" method for PatchEvent
with a series of Strings (which could be confused in order)
and instead am now using just the normal default struct
construction which effectively has named args.

Since EventType is now an enum, it's easy to use the
right enum not have to call PatchInstallEvent::new to
get the right magic string for "identifier".

Also added a bit more documentation to c_api.rs

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
