### PR TITLE
feat: report patch install failure events

### DIFF
--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -248,12 +248,11 @@ pub extern "C" fn shorebird_report_launch_success() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        network::PatchCheckResponse, testing_set_network_hooks, updater::testing_reset_config,
-    };
+    use crate::network::{testing_set_network_hooks, PatchCheckResponse};
     use anyhow::Ok;
     use serial_test::serial;
     use tempdir::TempDir;
+    use updater::testing_reset_config;
 
     use std::{ffi::CString, ptr::null_mut};
 

--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -45,7 +45,6 @@ pub struct UpdaterState {
     cache_dir: PathBuf,
     /// The client ID for this device.
     pub client_id: Option<String>,
-    // Add file path or FD so modifying functions can save it to disk?
 
     // Per-release state:
     /// The release version this cache corresponds to.
@@ -114,11 +113,7 @@ impl UpdaterState {
     }
 
     pub fn copy_events(&self, limit: usize) -> Vec<PatchEvent> {
-        self.queued_events
-            .iter()
-            .take(limit)
-            .cloned()
-            .collect::<Vec<_>>()
+        self.queued_events.iter().take(limit).cloned().collect()
     }
 
     pub fn clear_events(&mut self) -> Result<()> {

--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum EventType {
     PatchInstallSuccess,
     PatchInstallFailure,

--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -1,12 +1,12 @@
 // This file's job is to deal with the update_server and network side
 // of the updater library.
 
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum EventType {
     PatchInstallSuccess,
-    // PatchInstallFailure,
+    PatchInstallFailure,
 }
 
 impl Serialize for EventType {
@@ -16,16 +16,32 @@ impl Serialize for EventType {
     {
         serializer.serialize_str(match self {
             EventType::PatchInstallSuccess => "__patch_install__",
-            // EventType::PatchInstallFailure => "__patch_install_failure__",
+            EventType::PatchInstallFailure => "__patch_install_failure__",
         })
     }
 }
 
+impl<'de> Deserialize<'de> for EventType {
+    fn deserialize<D>(deserializer: D) -> Result<EventType, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "__patch_install__" => Ok(EventType::PatchInstallSuccess),
+            "__patch_install_failure__" => Ok(EventType::PatchInstallFailure),
+            _ => Err(serde::de::Error::custom(format!(
+                "Unknown event type: {}",
+                s
+            ))),
+        }
+    }
+}
 /// Any edits to this struct should be made carefully and in accordance
 /// with our privacy policy:
 /// https://docs.shorebird.dev/privacy
 /// An event that is sent to the server when a patch is successfully installed.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PatchEvent {
     /// The Shorebird app_id built into the shorebird.yaml in the app.
     pub app_id: String,

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -10,7 +10,7 @@ use std::string::ToString;
 
 use crate::cache::UpdaterState;
 use crate::config::{current_arch, current_platform, UpdateConfig};
-use crate::events::{EventType, PatchEvent};
+use crate::events::PatchEvent;
 
 // https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests
 #[cfg(test)]
@@ -259,20 +259,7 @@ pub fn send_patch_check_request(
     return Ok(response);
 }
 
-pub fn report_successful_patch_install(
-    config: &UpdateConfig,
-    client_id: String,
-    patch_number: usize,
-) -> anyhow::Result<()> {
-    let event = PatchEvent {
-        app_id: config.app_id.clone(),
-        arch: current_arch().to_string(),
-        client_id,
-        patch_number,
-        platform: current_platform().to_string(),
-        release_version: config.release_version.clone(),
-        identifier: EventType::PatchInstallSuccess,
-    };
+pub fn send_patch_event(event: PatchEvent, config: &UpdateConfig) -> anyhow::Result<()> {
     let request = CreatePatchEventRequest { event };
 
     let patch_install_success_fn = config.network_hooks.patch_install_success_fn;
@@ -306,6 +293,7 @@ mod tests {
     use crate::network::PatchCheckResponse;
 
     use super::{patches_events_url, PatchEvent};
+    use crate::events::EventType;
 
     #[test]
     fn check_patch_request_response_deserialization() {
@@ -339,7 +327,7 @@ mod tests {
             patch_number: 1,
             platform: "platform".to_string(),
             release_version: "release_version".to_string(),
-            identifier: super::EventType::PatchInstallSuccess,
+            identifier: EventType::PatchInstallSuccess,
         };
         let request = super::CreatePatchEventRequest { event };
         let json_string = serde_json::to_string(&request).unwrap();
@@ -420,7 +408,7 @@ mod tests {
             patch_number: 2,
             platform: "platform".to_string(),
             release_version: "release_version".to_string(),
-            identifier: super::EventType::PatchInstallSuccess,
+            identifier: EventType::PatchInstallSuccess,
         };
         let result = super::patch_install_success_default(
             // Make the request to a non-existent URL, which will trigger the
@@ -448,7 +436,7 @@ mod tests {
                     patch_number: 2,
                     platform: "platform".to_string(),
                     release_version: "release_version".to_string(),
-                    identifier: super::EventType::PatchInstallSuccess,
+                    identifier: EventType::PatchInstallSuccess,
                 },
             },
         );

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -409,6 +409,8 @@ pub fn report_launch_failure() -> anyhow::Result<()> {
         // Queue the failure event for later sending since right after this
         // function returns the Flutter engine is likely to abort().
         state.queue_event(event);
+        // TODO(eseidel): This does the actual save for the above mutations
+        // which is confusing.
         state
             .activate_latest_bootable_patch()
             .map_err(|err| anyhow::Error::from(err))


### PR DESCRIPTION
This doesn't tell us anything about the failure, just that it
happened.  Which at least will let us communicate that to customers.

This currently has no tests and will need some before landing.
