### PR TITLE
chore: fix 30 of the 54 warnings from clippy pedantic.

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -70,6 +70,6 @@ simple-logging = "2.0.2"
 serial_test = "2.0.0"
 tempdir = "0.3.7"
 
-# https://github.com/eqrion/cbindgen/blob/master/docs.md#buildrs
+# <https://github.com/eqrion/cbindgen/blob/master/docs.md#buildrs>
 [build-dependencies]
 cbindgen = "0.24.0"

--- a/library/build.rs
+++ b/library/build.rs
@@ -3,9 +3,9 @@ extern crate cbindgen;
 use std::env;
 
 // See:
-// https://github.com/eqrion/cbindgen/blob/master/docs.md#buildrs
-// https://doc.rust-lang.org/cargo/reference/build-scripts.html
-// https://doc.rust-lang.org/cargo/reference/build-script-examples.html
+// <https://github.com/eqrion/cbindgen/blob/master/docs.md#buildrs>
+// <https://doc.rust-lang.org/cargo/reference/build-scripts.html>
+// <https://doc.rust-lang.org/cargo/reference/build-script-examples.html>
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
@@ -16,7 +16,7 @@ fn main() {
             contents.write_to_file("include/updater.h");
         }
         Err(e) => {
-            println!("cargo:warning=Error generating bindings: {}", e);
+            println!("cargo:warning=Error generating bindings: {e}");
             // If we were to exit 1 here we would stop local rust
             // analysis from working. So we just print the error
             // and continue.

--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -104,11 +104,11 @@ SHOREBIRD_EXPORT void shorebird_start_update_thread(void);
 
 /**
  * Tell the updater that we're launching from what it told us was the
- * next patch to boot from. This will copy the next_boot patch to be the
- * current_boot patch.
+ * next patch to boot from. This will copy the next boot patch to be the
+ * `current_boot` patch.
  *
  * It is required to call this function before calling
- * shorebird_report_launch_success or shorebird_report_launch_failure.
+ * `shorebird_report_launch_success` or `shorebird_report_launch_failure`.
  */
 SHOREBIRD_EXPORT void shorebird_report_launch_start(void);
 

--- a/library/src/android.rs
+++ b/library/src/android.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 
-// https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests
+// <https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests>
 #[cfg(test)]
 use std::println as debug; // Workaround to use println! for logs.
 

--- a/library/src/c_api.rs
+++ b/library/src/c_api.rs
@@ -2,21 +2,21 @@
 
 // Currently manually prefixing all functions with "shorebird_" to avoid
 // name collisions with other libraries.
-// cbindgen:prefix-with-name could do this for us.
+// `cbindgen:prefix-with-name` could do this for us.
 
 /// This file contains the C API for the updater library.
 /// It is intended to be used by language bindings, and is not intended to be
 /// used directly by Rust code.
 /// The C API is not stable and may change at any time.
 /// You can see usage of this API in Shorebird's Flutter engine:
-/// https://github.com/shorebirdtech/engine/blob/shorebird/dev/shell/common/shorebird.cc
+/// <https://github.com/shorebirdtech/engine/blob/shorebird/dev/shell/common/shorebird.cc>
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::PathBuf;
 
 use crate::updater;
 
-// https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests
+// <https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests>
 #[cfg(test)]
 use std::{println as info, println as error}; // Workaround to use println! for logs.
 
@@ -130,11 +130,7 @@ pub extern "C" fn shorebird_should_auto_update() -> bool {
 #[no_mangle]
 pub extern "C" fn shorebird_current_boot_patch_number() -> usize {
     log_on_error(
-        || {
-            Ok(updater::current_boot_patch()?
-                .map(|p| p.number)
-                .unwrap_or(0))
-        },
+        || Ok(updater::current_boot_patch()?.map_or(0, |p| p.number)),
         "fetching next_boot_patch_number",
         0,
     )
@@ -145,7 +141,7 @@ pub extern "C" fn shorebird_current_boot_patch_number() -> usize {
 #[no_mangle]
 pub extern "C" fn shorebird_next_boot_patch_number() -> usize {
     log_on_error(
-        || Ok(updater::next_boot_patch()?.map(|p| p.number).unwrap_or(0)),
+        || Ok(updater::next_boot_patch()?.map_or(0, |p| p.number)),
         "fetching next_boot_patch_number",
         0,
     )
@@ -210,11 +206,11 @@ pub extern "C" fn shorebird_start_update_thread() {
 }
 
 /// Tell the updater that we're launching from what it told us was the
-/// next patch to boot from. This will copy the next_boot patch to be the
-/// current_boot patch.
+/// next patch to boot from. This will copy the next boot patch to be the
+/// `current_boot` patch.
 ///
 /// It is required to call this function before calling
-/// shorebird_report_launch_success or shorebird_report_launch_failure.
+/// `shorebird_report_launch_success` or `shorebird_report_launch_failure`.
 #[no_mangle]
 pub extern "C" fn shorebird_report_launch_start() {
     log_on_error(updater::report_launch_start, "reporting launch start", ());

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -85,7 +85,7 @@ pub struct UpdateConfig {
 pub fn set_config(
     app_config: AppConfig,
     libapp_path: PathBuf,
-    yaml: YamlConfig,
+    yaml: &YamlConfig,
     network_hooks: NetworkHooks,
 ) -> anyhow::Result<()> {
     with_config_mut(|config| {

--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -30,16 +30,13 @@ impl<'de> Deserialize<'de> for EventType {
         match s.as_str() {
             "__patch_install__" => Ok(EventType::PatchInstallSuccess),
             "__patch_install_failure__" => Ok(EventType::PatchInstallFailure),
-            _ => Err(serde::de::Error::custom(format!(
-                "Unknown event type: {}",
-                s
-            ))),
+            _ => Err(serde::de::Error::custom(format!("Unknown event type: {s}"))),
         }
     }
 }
 /// Any edits to this struct should be made carefully and in accordance
 /// with our privacy policy:
-/// https://docs.shorebird.dev/privacy
+/// <https://docs.shorebird.dev/privacy>
 /// An event that is sent to the server when a patch is successfully installed.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PatchEvent {

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -17,11 +17,11 @@ use crate::events::PatchEvent;
 use std::{println as info, println as debug}; // Workaround to use println! for logs.
 
 fn patches_check_url(base_url: &str) -> String {
-    format!("{}/api/v1/patches/check", base_url)
+    format!("{base_url}/api/v1/patches/check")
 }
 
 fn patches_events_url(base_url: &str) -> String {
-    format!("{}/api/v1/patches/events", base_url)
+    format!("{base_url}/api/v1/patches/events")
 }
 
 pub type PatchCheckRequestFn = fn(&str, PatchCheckRequest) -> anyhow::Result<PatchCheckResponse>;
@@ -186,7 +186,7 @@ pub struct Patch {
 
 /// Any edits to this struct should be made carefully and in accordance
 /// with our privacy policy:
-/// https://docs.shorebird.dev/privacy
+/// <https://docs.shorebird.dev/privacy>
 /// The request body for the patch check endpoint.
 #[derive(Debug, Serialize)]
 pub struct PatchCheckRequest {
@@ -194,7 +194,7 @@ pub struct PatchCheckRequest {
     /// app_ids are unique to each app and are used to identify the app
     /// within Shorebird's system (similar to a bundle identifier).  They
     /// are not secret and are safe to share publicly.
-    /// https://docs.shorebird.dev/concepts
+    /// <https://docs.shorebird.dev/concepts>
     pub app_id: String,
     /// The Shorebird channel built into the shorebird.yaml in the app.
     /// This is not currently used, but intended for future use to allow
@@ -218,7 +218,7 @@ pub struct PatchCheckRequest {
 /// The request body for the create patch install event endpoint.
 ///
 /// We may want to consider making this more generic if/when we add more events
-/// using something like https://github.com/dtolnay/typetag.
+/// using something like <https://github.com/dtolnay/typetag>.
 #[derive(Debug, Serialize)]
 pub struct CreatePatchEventRequest {
     event: PatchEvent,

--- a/library/src/updater_lock.rs
+++ b/library/src/updater_lock.rs
@@ -39,7 +39,9 @@ where
         // This should never happen. Poisoning only happens if a thread panics
         // while holding the lock, and we never allow the updater thread to
         // panic.
-        Err(std::sync::TryLockError::Poisoned(e)) => panic!("Updater lock poisoned: {:?}", e),
+        Err(std::sync::TryLockError::Poisoned(e)) => {
+            panic!("Updater lock poisoned: {e:?}")
+        }
     }
 }
 

--- a/patch/src/bin/string_patch.rs
+++ b/patch/src/bin/string_patch.rs
@@ -1,6 +1,8 @@
 // This might combine with patch/main.rs. Just starting with a copy for ease.
 
 fn main() {
+    use sha2::{Digest, Sha256}; // Digest is needed for Sha256::new();
+
     let mut args = std::env::args();
     args.next(); // skip program name
     let older = args.next().expect("base string");
@@ -14,13 +16,12 @@ fn main() {
 
     let patch = patch.into_inner();
 
-    use sha2::{Digest, Sha256}; // Digest is needed for Sha256::new();
     let mut hasher = Sha256::new();
     hasher.update(&newer);
     let hash = hasher.finalize();
 
-    println!("Base: {}", older);
-    println!("New: {}", newer);
-    println!("Patch: {:?}", patch);
+    println!("Base: {older}");
+    println!("New: {newer}");
+    println!("Patch: {patch:?}");
     println!("Hash (new): {}", hex::encode(hash));
 }


### PR DESCRIPTION
I just ran `cargo clippy -- -W clippy::pedantic` and fixed things.

These are more invasive that the default set and the remaining
warnings are mostly about our (abysmal) public docs missing
Error and Panic sections to explain errors and panicks.
