### PR TITLE
fix: add separate storage dir for state

### DIFF
--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -36,9 +36,15 @@ typedef struct AppParameters {
    */
   int original_libapp_paths_size;
   /**
-   * Path to cache_dir where the updater will store downloaded artifacts.
+   * Path to app storage directory where the updater will store serialized
+   * state and other data that persists between releases.
    */
-  const char *cache_dir;
+  const char *app_storage_dir;
+  /**
+   * Path to cache directory where the updater will store downloaded
+   * artifacts and data that can be deleted when a new release is detected.
+   */
+  const char *code_cache_dir;
 } AppParameters;
 
 #ifdef __cplusplus

--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -162,17 +162,21 @@ impl UpdaterState {
     }
 
     fn create_new_and_save(
-        cache_dir: &Path,
+        storage_dir: &Path,
         release_version: &str,
         client_id: Option<String>,
     ) -> Self {
-        let state = Self::new(cache_dir.to_owned(), release_version.to_owned(), client_id);
+        let state = Self::new(
+            storage_dir.to_owned(),
+            release_version.to_owned(),
+            client_id,
+        );
         let _ = state.save();
         state
     }
 
-    pub fn load_or_new_on_error(cache_dir: &Path, release_version: &str) -> Self {
-        let load_result = Self::load(cache_dir);
+    pub fn load_or_new_on_error(storage_dir: &Path, release_version: &str) -> Self {
+        let load_result = Self::load(storage_dir);
         match load_result {
             Ok(mut loaded) => {
                 let maybe_client_id = loaded.client_id.clone();
@@ -181,12 +185,20 @@ impl UpdaterState {
                         "release_version changed {} -> {}, clearing updater state",
                         loaded.release_version, release_version
                     );
-                    return Self::create_new_and_save(cache_dir, release_version, maybe_client_id);
+                    return Self::create_new_and_save(
+                        storage_dir,
+                        release_version,
+                        maybe_client_id,
+                    );
                 }
                 let validate_result = loaded.validate();
                 if let Err(e) = validate_result {
                     warn!("Error while validating state: {:#}, clearing state.", e);
-                    return Self::create_new_and_save(cache_dir, release_version, maybe_client_id);
+                    return Self::create_new_and_save(
+                        storage_dir,
+                        release_version,
+                        maybe_client_id,
+                    );
                 }
                 loaded
             }
@@ -194,7 +206,7 @@ impl UpdaterState {
                 if !is_file_not_found(&e) {
                     warn!("Error loading state: {:#}, clearing state.", e);
                 }
-                Self::create_new_and_save(cache_dir, release_version, None)
+                Self::create_new_and_save(storage_dir, release_version, None)
             }
         }
     }

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -71,7 +71,7 @@ where
 // The config passed into init.  This is immutable once set and copyable.
 #[derive(Debug, Clone)]
 pub struct UpdateConfig {
-    pub cache_dir: PathBuf,
+    pub storage_dir: PathBuf,
     pub download_dir: PathBuf,
     pub auto_update: bool,
     pub channel: String,
@@ -91,12 +91,12 @@ pub fn set_config(
     with_config_mut(|config| {
         anyhow::ensure!(config.is_none(), "shorebird_init has already been called.");
 
-        let mut cache_path = std::path::PathBuf::from(&app_config.cache_dir);
-        cache_path.push("downloads");
-        let download_dir = cache_path;
+        let mut code_cache_path = std::path::PathBuf::from(&app_config.code_cache_dir);
+        code_cache_path.push("downloads");
+        let download_dir = code_cache_path;
 
         let new_config = UpdateConfig {
-            cache_dir: std::path::PathBuf::from(app_config.cache_dir),
+            storage_dir: std::path::PathBuf::from(app_config.app_storage_dir),
             download_dir,
             channel: yaml
                 .channel


### PR DESCRIPTION
## Description

Adds a separate directory to store UpdateState (distinct from downloaded artifacts) to avoid UpdaterState getting wiped out between release versions on Android.

Part of https://github.com/shorebirdtech/shorebird/issues/1239

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
