### PR TITLE
fix: don't serialize UpdaterState cache_dir as it can change between app runs

### DIFF
--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -41,7 +41,9 @@ struct Slot {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct UpdaterState {
     // Per-device state:
-    /// Where this writes to disk.
+    /// Where this writes to disk. Don't serialize this field, as it can change
+    /// between runs of the app.
+    #[serde(skip)]
     cache_dir: PathBuf,
     /// The client ID for this device.
     pub client_id: Option<String>,
@@ -153,6 +155,7 @@ impl UpdaterState {
         // TODO: Now that we depend on serde_yaml for shorebird.yaml
         // we could use yaml here instead of json.
         let mut state: UpdaterState = serde_json::from_reader(reader)?;
+        state.cache_dir = cache_dir.to_path_buf();
         if state.client_id.is_none() {
             // Generate a client id if we don't already have one.
             state.client_id = Some(generate_client_id());

--- a/library/src/cache.rs
+++ b/library/src/cache.rs
@@ -638,4 +638,29 @@ mod tests {
         assert!(new_loaded.client_id.is_some());
         assert_eq!(original_loaded.client_id, new_loaded.client_id);
     }
+
+    #[test]
+    fn does_not_save_cache_dir() {
+        let original_tmp_dir = TempDir::new("example").unwrap();
+        let original_state = UpdaterState {
+            cache_dir: original_tmp_dir.path().to_path_buf(),
+            release_version: "1.0.0+1".to_string(),
+            client_id: None,
+            queued_events: Vec::new(),
+            current_boot_slot_index: None,
+            next_boot_slot_index: None,
+            failed_patches: Vec::new(),
+            successful_patches: Vec::new(),
+            slots: Vec::new(),
+        };
+        original_state.save().unwrap();
+
+        let new_tmp_dir = TempDir::new("example_2").unwrap();
+        let original_state_path = original_tmp_dir.path().join("state.json");
+        let new_state_path = new_tmp_dir.path().join("state.json");
+        std::fs::rename(original_state_path, new_state_path).unwrap();
+
+        let new_state = UpdaterState::load(new_tmp_dir.path()).unwrap();
+        assert_eq!(new_state.cache_dir, new_tmp_dir.path());
+    }
 }


### PR DESCRIPTION
## Description

Patches are sometimes failing to apply on iOS due to the reasons explained [here](https://github.com/shorebirdtech/shorebird/issues/1296#issuecomment-1728308059). In short, UpdaterState is saving its location, which is not always guaranteed to be accessible to the app, as iOS can move the app's home directory between runs.

Fixes https://github.com/shorebirdtech/shorebird/issues/1296

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
