### PR TITLE
fix: add delay to unstick download banner

### DIFF
--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -136,7 +136,7 @@ class _MyHomePageState extends State<MyHomePage> {
     await Future.wait([
       _shorebirdCodePush.downloadUpdateIfAvailable(),
       // Add an artificial delay so the banner has enough time to animate in.
-      Future<void>.delayed(const Duration(seconds: 1)),
+      Future<void>.delayed(const Duration(milliseconds: 250)),
     ]);
 
     if (!mounted) return;

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -136,7 +136,7 @@ class _MyHomePageState extends State<MyHomePage> {
     await Future.wait([
       _shorebirdCodePush.downloadUpdateIfAvailable(),
       // Add an artificial delay so the banner has enough time to animate in.
-      Future<void>.delayed(const Duration(milliseconds: 1000)),
+      Future<void>.delayed(const Duration(seconds: 1)),
     ]);
 
     if (!mounted) return;

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Shorebird Code Push Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.red),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Shorebird Code Push'),
@@ -132,7 +132,13 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _downloadUpdate() async {
     _showDownloadingBanner();
-    await _shorebirdCodePush.downloadUpdateIfAvailable();
+
+    await Future.wait([
+      _shorebirdCodePush.downloadUpdateIfAvailable(),
+      // Add an artificial delay so the banner has enough time to animate in.
+      Future<void>.delayed(const Duration(milliseconds: 1000)),
+    ]);
+
     if (!mounted) return;
 
     ScaffoldMessenger.of(context).hideCurrentMaterialBanner();

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Shorebird Code Push Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.red),
         useMaterial3: true,
       ),
       home: const MyHomePage(title: 'Shorebird Code Push'),


### PR DESCRIPTION
## Description

With small patches, the "downloading update" banner would sometimes not be replaced with the restart banner. This change adds a delay to ensure the downloading banner has time to fully animate in before we dismiss it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
