### PR TITLE
chore: don't error log if patches_state.json doesn't exist

### DIFF
--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -11,7 +11,7 @@ use tempdir::TempDir;
 
 // https://stackoverflow.com/questions/67087597/is-it-possible-to-use-rusts-log-info-for-tests
 #[cfg(test)]
-use std::{println as info, println as error}; // Workaround to use println! for logs.
+use std::{println as info, println as error, println as debug}; // Workaround to use println! for logs.
 
 const PATCHES_DIR_NAME: &str = "patches";
 const PATCHES_STATE_FILE_NAME: &str = "patches_state.json";
@@ -116,7 +116,7 @@ impl PatchManager {
         match disk_io::read(&path) {
             Ok(maybe_state) => maybe_state,
             Err(e) => {
-                error!(
+                debug!(
                     "Failed to load patches state from {}: {}",
                     path.display(),
                     e


### PR DESCRIPTION
## Description

This is not an error (patches_state.json is expected to not exist on the first launch of a release) and generates a ton of log noise. Reduce the log severity to debug.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
