### PR TITLE
chore(shorebird_code_push): remove error log when shorebird is unavailable

### DIFF
--- a/shorebird_code_push/lib/src/shorebird_code_push_io.dart
+++ b/shorebird_code_push/lib/src/shorebird_code_push_io.dart
@@ -25,8 +25,6 @@ class ShorebirdCodePush implements ShorebirdCodePushBase {
       updater.currentPatchNumber();
       _delegate = ShorebirdCodePushFfi(updater: updater);
     } catch (error) {
-      // ignore: avoid_print
-      print('[ShorebirdCodePush]: Error initializing updater: $error');
       _delegate = ShorebirdCodePushNoop();
     }
   }

--- a/shorebird_code_push/test/shorebird_code_push_io_test.dart
+++ b/shorebird_code_push/test/shorebird_code_push_io_test.dart
@@ -35,14 +35,11 @@ void main() {
       expect(shorebirdCodePush, isNotNull);
       expect(
         printLogs,
-        [
-          startsWith(
-            '''[ShorebirdCodePush]: Error initializing updater: Invalid argument(s): Failed to lookup symbol''',
-          ),
-          equals(
+        equals(
+          [
             '''[ShorebirdCodePush]: Shorebird Engine not available, using no-op implementation.\n''',
-          ),
-        ],
+          ],
+        ),
       );
     });
 
@@ -58,12 +55,11 @@ void main() {
       );
       expect(
         printLogs,
-        [
-          equals('[ShorebirdCodePush]: Error initializing updater: $exception'),
-          equals(
+        equals(
+          [
             '''[ShorebirdCodePush]: Shorebird Engine not available, using no-op implementation.\n''',
-          ),
-        ],
+          ],
+        ),
       );
     });
 


### PR DESCRIPTION
## Description

This log causes the following error to be printed to the console when the shorebird bindings are not available: `[ShorebirdCodePush]: Error initializing updater: Invalid argument(s): Failed to lookup symbol 'shorebird_current_boot_patch_number': undefined symbol: shorebird_current_boot_patch_number`. This error is confusing and unhelpful, especially since it is immediately followed by `[ShorebirdCodePush]: Shorebird Engine not available, using no-op implementation.`, which is clearer and more helpful.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
