### PR TITLE
test: use mockito crate to test network-interfacing code

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -66,6 +66,7 @@ simple-logging = "2.0.2"
 
 [dev-dependencies]
 mockall = "0.11.4"
+mockito = "1.2.0"
 # Gives #[serial] attribute for locking all of our shorebird_init
 # tests to a single thread so they don't conflict with each other.
 serial_test = "2.0.0"

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -16,7 +16,13 @@ use std::println as debug; // Workaround to use println! for logs.
 // cbindgen looks for const, ignore these so it doesn't warn about them.
 
 /// cbindgen:ignore
+#[cfg(test)]
+const DEFAULT_BASE_URL: &str = "DEFAULT_BASE_URL should be mocked using mockito::Server";
+
+/// cbindgen:ignore
+#[cfg(not(test))]
 const DEFAULT_BASE_URL: &str = "https://api.shorebird.dev";
+
 /// cbindgen:ignore
 const DEFAULT_CHANNEL: &str = "stable";
 

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -50,26 +50,7 @@ impl core::fmt::Debug for NetworkHooks {
     }
 }
 
-#[cfg(test)]
-fn patch_check_request_throws(
-    _url: &str,
-    _request: PatchCheckRequest,
-) -> anyhow::Result<PatchCheckResponse> {
-    bail!("please set a patch_check_request_fn");
-}
-
-#[cfg(test)]
-fn download_file_throws(_url: &str) -> anyhow::Result<Vec<u8>> {
-    bail!("please set a download_file_fn");
-}
-
-#[cfg(test)]
-pub fn report_event_throws(_url: &str, _request: CreatePatchEventRequest) -> anyhow::Result<()> {
-    bail!("please set a report_event_fn");
-}
-
 impl Default for NetworkHooks {
-    #[cfg(not(test))]
     fn default() -> Self {
         Self {
             patch_check_request_fn: patch_check_request_default,
@@ -77,18 +58,8 @@ impl Default for NetworkHooks {
             report_event_fn: report_event_default,
         }
     }
-
-    #[cfg(test)]
-    fn default() -> Self {
-        Self {
-            patch_check_request_fn: patch_check_request_throws,
-            download_file_fn: download_file_throws,
-            report_event_fn: report_event_throws,
-        }
-    }
 }
 
-#[cfg(not(test))]
 pub fn patch_check_request_default(
     url: &str,
     request: PatchCheckRequest,
@@ -99,7 +70,6 @@ pub fn patch_check_request_default(
     Ok(response)
 }
 
-#[cfg(not(test))]
 pub fn download_file_default(url: &str) -> anyhow::Result<Vec<u8>> {
     let client = reqwest::blocking::Client::new();
     let result = client.get(url).send();
@@ -166,7 +136,7 @@ pub fn testing_set_network_hooks(
     });
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Patch {
     /// The patch number.  Starts at 1 for each new release and increases
     /// monotonically.
@@ -218,7 +188,7 @@ pub struct CreatePatchEventRequest {
     event: PatchEvent,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PatchCheckResponse {
     pub patch_available: bool,
     #[serde(default)]

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -755,13 +755,13 @@ mod tests {
         use crate::config::{current_arch, current_platform, with_config};
         use crate::events::{EventType, PatchEvent};
         use crate::network::PatchCheckResponse;
+
+        let mut server = mockito::Server::new();
         let check_response = PatchCheckResponse {
             patch_available: false,
             patch: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
-
-        let mut server = mockito::Server::new();
         let _ = server
             .mock("POST", "/api/v1/patches/check")
             .with_status(200)


### PR DESCRIPTION
## Description

Updates the `updater.rs` tests to use stubbed network endpoints (via the [mockito](https://docs.rs/mockito/latest/mockito/) crate), which allows us to verify the number of times a given endpoint was called.

Once this lands, future PRs will update tests to use this pattern, eventually removing the `testing_set_network_hooks` functionality and potentially the `NetworkHooks` struct entirely.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
