### PR TITLE
refactor: remove client_id

### DIFF
--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -46,9 +46,6 @@ pub struct PatchEvent {
     /// The architecture we're running (e.g. "aarch64", "x86", "x86_64").
     pub arch: String,
 
-    /// The unique ID of this device.
-    pub client_id: String,
-
     /// The identifier of this event.
     #[serde(rename = "type")]
     pub identifier: EventType,

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -288,7 +288,6 @@ mod tests {
         let event = PatchEvent {
             app_id: "app_id".to_string(),
             arch: "arch".to_string(),
-            client_id: "client_id".to_string(),
             patch_number: 1,
             platform: "platform".to_string(),
             release_version: "release_version".to_string(),
@@ -298,7 +297,7 @@ mod tests {
         let json_string = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json_string,
-            r#"{"event":{"app_id":"app_id","arch":"arch","client_id":"client_id","type":"__patch_install__","patch_number":1,"platform":"platform","release_version":"release_version"}}"#
+            r#"{"event":{"app_id":"app_id","arch":"arch","type":"__patch_install__","patch_number":1,"platform":"platform","release_version":"release_version"}}"#
         )
     }
 
@@ -369,7 +368,6 @@ mod tests {
         let event = PatchEvent {
             app_id: "app_id".to_string(),
             arch: "arch".to_string(),
-            client_id: "client_id".to_string(),
             patch_number: 2,
             platform: "platform".to_string(),
             release_version: "release_version".to_string(),
@@ -397,7 +395,6 @@ mod tests {
                 event: PatchEvent {
                     app_id: "app_id".to_string(),
                     arch: "arch".to_string(),
-                    client_id: "client_id".to_string(),
                     patch_number: 2,
                     platform: "platform".to_string(),
                     release_version: "release_version".to_string(),

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -406,7 +406,6 @@ pub fn report_launch_failure() -> anyhow::Result<()> {
         let event = PatchEvent {
             app_id: config.app_id.clone(),
             arch: current_arch().to_string(),
-            client_id: state.client_id_or_default(),
             identifier: EventType::PatchInstallFailure,
             patch_number: patch.number,
             platform: current_platform().to_string(),
@@ -447,12 +446,10 @@ pub fn report_launch_success() -> anyhow::Result<()> {
         }
 
         let config_copy = config.clone();
-        let client_id = state.client_id_or_default();
         std::thread::spawn(move || {
             let event = PatchEvent {
                 app_id: config_copy.app_id.clone(),
                 arch: current_arch().to_string(),
-                client_id,
                 patch_number: next_boot_patch.number,
                 platform: current_platform().to_string(),
                 release_version: config_copy.release_version.clone(),
@@ -780,7 +777,6 @@ mod tests {
             let fail_event = PatchEvent {
                 app_id: config.app_id.clone(),
                 arch: current_arch().to_string(),
-                client_id: state.client_id_or_default(),
                 identifier: EventType::PatchInstallFailure,
                 patch_number: 1,
                 platform: current_platform().to_string(),


### PR DESCRIPTION
We added client_id back when we had a different billing model
where we would bill customers based on number of unique devices
accepting an install in a given month (similar to what expo.dev
advertised as their pricing model at the time).

We moved to a differnet pricing model and never used client_id
so removing it.