### PR TITLE
fix: us OSLog framework for logging on iOS

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -62,8 +62,8 @@ log-panics = { version = "2", features = ["with-backtrace"] }
 [target.'cfg(target_os = "ios")'.dependencies]
 # Send panics to syslog (instead of stderr).
 log-panics = { version = "2", features = ["with-backtrace"] }
-# Use stderr for logging on iOS.
-simple-logging = "2.0.2"
+# Support for logging on iOS (https://developer.apple.com/documentation/oslog)
+oslog = "0.2.0"
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/library/src/logging.rs
+++ b/library/src/logging.rs
@@ -13,11 +13,8 @@ pub fn init_logging() {
 
 #[cfg(target_os = "ios")]
 pub fn init_logging() {
-    use log::LevelFilter;
-
     let init_result = oslog::OsLogger::new("dev.shorebird")
-        .level_filter(LevelFilter::Debug)
-        .category_level_filter("Settings", LevelFilter::Info)
+        .level_filter(log::LevelFilter::Info)
         .init();
     match init_result {
         Ok(_) => debug!("Logging initialized"),

--- a/library/src/logging.rs
+++ b/library/src/logging.rs
@@ -13,10 +13,16 @@ pub fn init_logging() {
 
 #[cfg(target_os = "ios")]
 pub fn init_logging() {
-    // I could not figure out how to get fancier logging set up on iOS
-    // but logging to stderr seems to work.
-    simple_logging::log_to(std::io::stderr(), log::LevelFilter::Info);
-    debug!("Logging initialized");
+    use log::LevelFilter;
+
+    let init_result = oslog::OsLogger::new("dev.shorebird")
+        .level_filter(LevelFilter::Debug)
+        .category_level_filter("Settings", LevelFilter::Info)
+        .init();
+    match init_result {
+        Ok(_) => debug!("Logging initialized"),
+        Err(e) => error!("Failed to initialize logging: {}", e),
+    }
 }
 
 #[cfg(all(not(target_os = "android"), not(target_os = "ios")))]


### PR DESCRIPTION
## Description

Updates logging on iOS to print rust logs to output (currently, only Flutter engine FML_LOGs are being written to the console).

Replaces the `simple_logging` crate with the `oslog` crate. I'm a bit torn on using `oslog` as it doesn't seem to be very actively contributed to or to have many stars on GitHub, but it has some pretty [high-profile users](https://crates.io/crates/oslog/reverse_dependencies), it's simple, and it seems to work, so 

Note that this exposes some error logs that we will want to clean up (probably along with https://github.com/shorebirdtech/updater/issues/119), for example: 

```
2024-02-06 15:23:23.657521-0500 Runner[674:37487] [updater::cache::updater_state] Error loading state: File /private/var/mobile/Containers/Data/Application/E15D3235-7B43-4DA8-BA71-80E83A4D448C/Library/Application Support/shorebird/shorebird_updater/state.json does not exist, clearing state.
```

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
