### PR TITLE
fix(patch): statically link C runtime for Windows patch binaries

### DIFF
--- a/patch/.cargo/config.toml
+++ b/patch/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+
+[target.i586-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
## Description

Adds a `.cargo/config` file to the `patch` library to statically link the C runtime for windows builds. 

Fixes https://github.com/shorebirdtech/shorebird/issues/1487

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
