### PR TITLE
fix(patch): update crt-static flag in build config

### DIFF
--- a/patch/.cargo/config.toml
+++ b/patch/.cargo/config.toml
@@ -1,4 +1,4 @@
 # Prevents missing DLLs when running the binary on Windows
 # See https://github.com/shorebirdtech/shorebird/issues/1487
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-Ctarget-feature=+crt-static"]
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Description

As per https://github.com/rust-lang/rust/issues/100874#issuecomment-1222405985.

The patch.exe being generated by `cargo build --release` is ~96KB larger than the artifact being downloaded by the shorebird cli, which looks to be roughly the size of some (but not all 🙃) of the VCRUNTIME140.dll files I'm finding on my system.

Fixes https://github.com/shorebirdtech/shorebird/issues/1487

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
