### PR TITLE
fix: verify failed patch is next_boot_patch before clearing

### DIFF
--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -837,6 +837,7 @@ mod fall_back_tests {
         manager.add_patch_for_test(&temp_dir, 1)?;
 
         // Start booting from patch 1.
+        manager.record_boot_start_for_patch(1)?;
 
         // Download patch 2 before patch 1 finishes booting.
         manager.add_patch_for_test(&temp_dir, 2)?;

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -248,6 +248,7 @@ impl PatchManager {
     /// successfully booted patch. If the last successfully booted patch is not bootable or has the same number
     /// as the patch we're falling back from, we clear it as well.
     fn try_fall_back_from_patch(&mut self, bad_patch_number: usize) {
+        // No need to log failure – delete_patch_artifacts logs for us.
         let _ = self.delete_patch_artifacts(bad_patch_number);
 
         if let Some(next_boot_patch) = self.patches_state.next_boot_patch {
@@ -271,6 +272,7 @@ impl PatchManager {
                 self.patches_state.next_boot_patch = Some(last_boot_patch);
             } else {
                 self.patches_state.last_booted_patch = None;
+                // No need to log failure – delete_patch_artifacts logs for us.
                 let _ = self.delete_patch_artifacts(last_boot_patch.number);
             }
         }

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -255,22 +255,15 @@ impl PatchManager {
             // If our next boot patch is bad_patch_number, clear it.
             if next_boot_patch.number == bad_patch_number {
                 self.patches_state.next_boot_patch = None;
-
-                // If the last booted patch also the bad patch (i.e., if we had
-                // previously booted from this patch and it is now failing validation),
-                // clear it as well.
-                if let Some(last_boot_patch) = self.patches_state.last_booted_patch {
-                    if last_boot_patch.number == bad_patch_number {
-                        self.patches_state.last_booted_patch = None;
-                    }
-                }
             }
         }
 
         // If we think we can still boot from the last booted patch, set it as the next_boot_patch.
         // If something happened to render the last boot patch unbootable, clear it and delete its artifacts.
         if let Some(last_boot_patch) = self.patches_state.last_booted_patch {
-            if self.validate_patch_is_bootable(&last_boot_patch).is_ok() {
+            if last_boot_patch.number != bad_patch_number
+                && self.validate_patch_is_bootable(&last_boot_patch).is_ok()
+            {
                 self.patches_state.next_boot_patch = Some(last_boot_patch);
             } else {
                 self.patches_state.last_booted_patch = None;

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -256,7 +256,9 @@ impl PatchManager {
             if next_boot_patch.number == bad_patch_number {
                 self.patches_state.next_boot_patch = None;
 
-                // If the last booted patch is the same as the next boot patch, clear it.
+                // If the last booted patch also the bad patch (i.e., if we had
+                // previously booted from this patch and it is now failing validation),
+                // clear it as well.
                 if let Some(last_boot_patch) = self.patches_state.last_booted_patch {
                     if last_boot_patch.number == bad_patch_number {
                         self.patches_state.last_booted_patch = None;


### PR DESCRIPTION
## Description

Removes assumption that a failed patch is `next_boot_patch` in fallback behavior.

Fixes https://github.com/shorebirdtech/updater/issues/148

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
