### PR TITLE
fix: delete all old patch artifacts on successful boot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["library", "patch"]
+resolver = "2"

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -837,6 +837,7 @@ mod fall_back_tests {
         manager.add_patch_for_test(&temp_dir, 1)?;
 
         // Start booting from patch 1.
+        manager.record_boot_start_for_patch(1)?;
 
         // Download patch 2 before patch 1 finishes booting.
         manager.add_patch_for_test(&temp_dir, 2)?;

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -61,15 +61,15 @@ pub trait ManagePatches {
 
     /// Returns the next patch to boot, or None if:
     /// - no patches have been downloaded
-    /// - the patch on disk is not bootable
+    /// - we cannot boot from the patch(es) on disk
     fn next_boot_patch(&mut self) -> Option<PatchInfo>;
 
     /// Record that we're booting. If we have a next path, updates the last
     /// attempted patch to be the next boot patch.
     fn record_boot_start_for_patch(&mut self, patch_number: usize) -> Result<()>;
 
-    /// Records that the patch with number patch_number booted successfully and is
-    /// safe to use for future boots.
+    /// Marks last_attempted_patch as "good", updates last_booted_patch to be the same,
+    /// and deletes all patch artifacts older than the last_booted_patch.
     fn record_boot_success(&mut self) -> Result<()>;
 
     /// Records that the patch with number patch_number failed to boot, and ensures

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -404,7 +404,12 @@ impl ManagePatches for PatchManager {
             .context("No last_attempted_patch")?;
 
         self.patches_state.last_booted_patch = Some(boot_patch);
-        let _ = self.delete_patch_artifacts_older_than(boot_patch.number);
+        if let Err(e) = self.delete_patch_artifacts_older_than(boot_patch.number) {
+            error!(
+                "Failed to delete patch artifacts older than {}: {}",
+                boot_patch.number, e
+            );
+        }
         self.save_patches_state()
     }
 

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -279,6 +279,14 @@ impl PatchManager {
     }
 
     /// Deletes all patch artifacts with numbers less than patch_number.
+    /// We intentionally only delete older patch artifacts. Consider the case:
+    ///
+    /// 1. We start booting patch 2
+    /// 2. While booting (i.e., in between boot start and boot success), we download and inflate patch 3
+    /// 3. We finish booting patch 2
+    ///
+    /// Deleting all other patch artifacts would delete patch 3, and because we've "seen" patch 3,
+    /// we would never try to download it again (it would be considered "bad").
     fn delete_patch_artifacts_older_than(&mut self, patch_number: usize) -> Result<()> {
         for entry in std::fs::read_dir(self.patches_dir())? {
             let entry = entry?;

--- a/library/src/cache/updater_state.rs
+++ b/library/src/cache/updater_state.rs
@@ -145,9 +145,8 @@ impl UpdaterState {
     }
 
     /// Records that the patch with patch_number was successfully booted, marks the patch as "good".
-    pub fn record_boot_success_for_patch(&mut self, patch_number: usize) -> Result<()> {
-        self.patch_manager
-            .record_boot_success_for_patch(patch_number)
+    pub fn record_boot_success(&mut self) -> Result<()> {
+        self.patch_manager.record_boot_success()
     }
 
     /// The patch we most recently attempted to boot.
@@ -315,16 +314,14 @@ mod tests {
 
     #[test]
     fn record_boot_success_for_patch_forwards_to_patch_manager() {
-        let patch_number = 1;
         let tmp_dir = TempDir::new("example").unwrap();
         let mut mock_manage_patches = MockManagePatches::new();
         mock_manage_patches
-            .expect_record_boot_success_for_patch()
-            .with(eq(patch_number))
-            .returning(|_| Ok(()));
+            .expect_record_boot_success()
+            .returning(|| Ok(()));
         let mut state = test_state(&tmp_dir, mock_manage_patches);
 
-        assert!(state.record_boot_success_for_patch(patch_number).is_ok());
+        assert!(state.record_boot_success().is_ok());
     }
 
     #[test]

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -451,7 +451,7 @@ pub fn report_launch_success() -> anyhow::Result<()> {
 
         let maybe_previous_boot_patch = state.current_boot_patch();
 
-        state.record_boot_success_for_patch(last_attempted_boot_patch.number)?;
+        state.record_boot_success()?;
 
         if let (Some(previous_boot_patch), Some(current_boot_patch)) =
             (maybe_previous_boot_patch, state.current_boot_patch())


### PR DESCRIPTION
## Description

On successful boot, deletes all patch artifacts belonging to patches older than the successfully booted patch.

Also changes `record_boot_success_for_patch` to `record_boot_success`, as the patch manager now knows which patch we're recording success for.

Fixes https://github.com/shorebirdtech/updater/issues/147

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
