### PR TITLE
fix: Don't make network request while holding config lock

### DIFF
--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -162,9 +162,22 @@ pub fn current_platform() -> &'static str {
 }
 
 #[cfg(test)]
+pub fn fake_yaml() -> crate::yaml::YamlConfig {
+    crate::yaml::YamlConfig {
+        app_id: "fake_app_id".to_string(),
+        channel: Some("fake_channel".to_string()),
+        auto_update: Some(true),
+        base_url: Some("fake_base_url".to_string()),
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::set_config;
-    use crate::{network::NetworkHooks, testing_reset_config, AppConfig, ExternalFileProvider};
+    use crate::{
+        config::fake_yaml, network::NetworkHooks, testing_reset_config, AppConfig,
+        ExternalFileProvider,
+    };
     use serial_test::serial;
 
     #[derive(Debug, Clone)]
@@ -181,15 +194,6 @@ mod tests {
             code_cache_dir: "/tmp".to_string(),
             release_version: "1.0.0".to_string(),
             original_libapp_paths: vec!["libapp.so".to_string()],
-        }
-    }
-
-    fn fake_yaml() -> crate::yaml::YamlConfig {
-        crate::yaml::YamlConfig {
-            app_id: "fake_app_id".to_string(),
-            channel: Some("fake_channel".to_string()),
-            auto_update: Some(true),
-            base_url: Some("fake_base_url".to_string()),
         }
     }
 

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -162,22 +162,9 @@ pub fn current_platform() -> &'static str {
 }
 
 #[cfg(test)]
-pub fn fake_yaml() -> crate::yaml::YamlConfig {
-    crate::yaml::YamlConfig {
-        app_id: "fake_app_id".to_string(),
-        channel: Some("fake_channel".to_string()),
-        auto_update: Some(true),
-        base_url: Some("fake_base_url".to_string()),
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::set_config;
-    use crate::{
-        config::fake_yaml, network::NetworkHooks, testing_reset_config, AppConfig,
-        ExternalFileProvider,
-    };
+    use crate::{network::NetworkHooks, testing_reset_config, AppConfig, ExternalFileProvider};
     use serial_test::serial;
 
     #[derive(Debug, Clone)]
@@ -194,6 +181,15 @@ mod tests {
             code_cache_dir: "/tmp".to_string(),
             release_version: "1.0.0".to_string(),
             original_libapp_paths: vec!["libapp.so".to_string()],
+        }
+    }
+
+    fn fake_yaml() -> crate::yaml::YamlConfig {
+        crate::yaml::YamlConfig {
+            app_id: "fake_app_id".to_string(),
+            channel: Some("fake_channel".to_string()),
+            auto_update: Some(true),
+            base_url: Some("fake_base_url".to_string()),
         }
     }
 

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -16,7 +16,7 @@ use crate::events::PatchEvent;
 #[cfg(test)]
 use std::{println as info, println as debug}; // Workaround to use println! for logs.
 
-fn patches_check_url(base_url: &str) -> String {
+pub fn patches_check_url(base_url: &str) -> String {
     format!("{base_url}/api/v1/patches/check")
 }
 

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -846,7 +846,7 @@ mod tests {
         // Set up the network hooks to sleep for 10 seconds on a patch check request
         let hooks = NetworkHooks {
             patch_check_request_fn: |_url, _request| {
-                let patch_check_delay = std::time::Duration::from_secs(2);
+                let patch_check_delay = std::time::Duration::from_secs(1);
                 std::thread::sleep(patch_check_delay);
 
                 // If we've obtained and released the config lock, this test has passed.

--- a/patch/src/main.rs
+++ b/patch/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
         eprintln!("  base:   Path to the base file");
         eprintln!("  new:    Path to the new file");
         eprintln!("  output: Path to the output patch file");
-        eprintln!("");
+        eprintln!();
         eprintln!(" This is an internal tool for creating binary diffs.");
         std::process::exit(1);
     }


### PR DESCRIPTION
Update `check_for_update_internal` to no longer hold the config lock while making a patch check request.

Fixes https://github.com/shorebirdtech/shorebird/issues/1981