### PR TITLE
refactor: remove duplicated sent_patch_check_request code

### DIFF
--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -67,6 +67,7 @@ pub fn patch_check_request_default(
     let client = reqwest::blocking::Client::new();
     let result = client.post(url).json(&request).send();
     let response = handle_network_result(result)?.json()?;
+    debug!("Patch check response: {:?}", response);
     Ok(response)
 }
 

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -14,8 +14,7 @@ use crate::config::{current_arch, current_platform, set_config, with_config, Upd
 use crate::events::{EventType, PatchEvent};
 use crate::logging::init_logging;
 use crate::network::{
-    download_to_path, patches_check_url, send_patch_check_request, NetworkHooks, PatchCheckRequest,
-    PatchCheckResponse,
+    download_to_path, patches_check_url, NetworkHooks, PatchCheckRequest, PatchCheckResponse,
 };
 use crate::time;
 use crate::updater_lock::{with_updater_thread_lock, UpdaterLockState};
@@ -295,7 +294,9 @@ fn update_internal(_: &UpdaterLockState) -> anyhow::Result<UpdateStatus> {
     })?;
 
     // Check for update.
-    let response = send_patch_check_request(&config, &read_only_state)?;
+    let request = patch_check_request(&config, &read_only_state);
+    let patch_check_request_fn = &(config.network_hooks.patch_check_request_fn);
+    let response = patch_check_request_fn(&patches_check_url(&config.base_url), request)?;
     if !response.patch_available {
         return Ok(UpdateStatus::NoUpdate);
     }


### PR DESCRIPTION
## Description

We had two ways of making a patch check request, but really only need one.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
