### PR TITLE
refactor: use known bad patches instead of highest seen patch number

### DIFF
--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -1249,12 +1249,10 @@ mod record_boot_failure_for_patch_tests {
 
         assert!(manager.patches_state.known_bad_patches.is_empty());
         manager.record_boot_failure_for_patch(1)?;
-        let bad_patches_vec: Vec<usize> = manager
-            .patches_state
-            .known_bad_patches
-            .into_iter()
-            .collect();
-        assert_eq!(bad_patches_vec, vec![1]);
+        assert_eq!(
+            manager.patches_state.known_bad_patches,
+            HashSet::from_iter(vec![1])
+        );
 
         Ok(())
     }

--- a/library/src/cache/updater_state.rs
+++ b/library/src/cache/updater_state.rs
@@ -198,15 +198,8 @@ impl UpdaterState {
             .add_patch(patch.number, &patch.path, hash, signature)
     }
 
-    /// Returns highest patch number that has been installed for this release.
-    /// This should represent the latest patch we still have on disk so as
-    /// to prevent re-downloading patches we already have.
-    /// This should essentially be the max of the patch number in the slots
-    /// and the bad patch list (we don't need to keep bad patches on disk
-    /// to know that they're bad).
-    /// Used by the patch check logic.
-    pub fn latest_seen_patch_number(&self) -> Option<usize> {
-        self.patch_manager.highest_seen_patch_number()
+    pub fn is_known_bad_patch(&self, patch_number: usize) -> bool {
+        self.patch_manager.is_known_bad_patch(patch_number)
     }
 }
 
@@ -284,7 +277,6 @@ mod tests {
         let mut next_version_state =
             UpdaterState::load_or_new_on_error(&state.cache_dir, "1.0.0+2", None);
         assert!(next_version_state.next_boot_patch().is_none());
-        assert!(next_version_state.latest_seen_patch_number().is_none());
     }
 
     #[test]
@@ -391,17 +383,5 @@ mod tests {
         assert!(state
             .install_patch(&patch, "hash", Some("signature"))
             .is_ok());
-    }
-
-    #[test]
-    fn latest_patch_number_returns_value_from_patch_manager() {
-        let highest_patch_number = 1;
-        let tmp_dir = TempDir::new("example").unwrap();
-        let mut mock_manage_patches = MockManagePatches::new();
-        mock_manage_patches
-            .expect_highest_seen_patch_number()
-            .return_const(Some(highest_patch_number));
-        let state = test_state(&tmp_dir, mock_manage_patches);
-        assert_eq!(state.latest_seen_patch_number(), Some(highest_patch_number));
     }
 }

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -154,14 +154,11 @@ pub fn should_auto_update() -> anyhow::Result<bool> {
 }
 
 fn patch_check_request(config: &UpdateConfig, state: &mut UpdaterState) -> PatchCheckRequest {
-    let latest_patch_number = state.next_boot_patch().map(|p| p.number);
-
-    // Send the request to the server.
     PatchCheckRequest {
         app_id: config.app_id.clone(),
         channel: config.channel.clone(),
         release_version: config.release_version.clone(),
-        patch_number: latest_patch_number,
+        patch_number: state.next_boot_patch().map(|p| p.number),
         platform: current_platform().to_string(),
         arch: current_arch().to_string(),
     }


### PR DESCRIPTION
## Description

Updates our patch check logic to:

1. Record patch numbers that fail to boot in a list of "known bad" patches.
3. When making a patch check request, send the next boot patch number instead of the highest we've previously seen.
4. If the server responds with a patch number that we have marked bad, do not attempt to download or install it.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
