### PR TITLE
feat: track known_bad_patches instead of highest_seen_patch to support rollbacks

### DIFF
--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -2,7 +2,10 @@ use super::{disk_io, signing, PatchInfo};
 use anyhow::{bail, Context, Result};
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 #[cfg(test)]
 use mockall::automock;
@@ -50,9 +53,10 @@ struct PatchesState {
     ///  - the system initializes (on_init, we take this to mean the patch failed to boot)
     currently_booting_patch: Option<PatchMetadata>,
 
-    /// The highest patch number we have seen. This may be higher than the last booted
-    /// patch or next patch if we downloaded a patch that failed to boot.
-    highest_seen_patch_number: Option<usize>,
+    /// A list of patch numbers that we have tried and failed to install.
+    /// We should never attempt to download or install these again for the
+    /// current release.
+    known_bad_patches: HashSet<usize>,
 }
 
 /// Abstracts the process of managing patches.
@@ -103,9 +107,8 @@ pub trait ManagePatches {
     /// that it will never be returned as the next boot or last booted patch.
     fn record_boot_failure_for_patch(&mut self, patch_number: usize) -> Result<()>;
 
-    /// The highest patch number that has been added. This may be higher than the
-    /// last booted or next boot patch if we downloaded a patch that failed to boot.
-    fn highest_seen_patch_number(&self) -> Option<usize>;
+    /// Whether we have failed to boot from the patch with `patch_number`.
+    fn is_known_bad_patch(&self, patch_number: usize) -> bool;
 
     /// Resets the patch manager to its initial state, removing all patches. This is
     /// intended to be used when a new release version is installed.
@@ -369,11 +372,6 @@ impl ManagePatches for PatchManager {
         }
 
         self.patches_state.next_boot_patch = Some(new_patch);
-        self.patches_state.highest_seen_patch_number = self
-            .patches_state
-            .highest_seen_patch_number
-            .map(|highest_patch_number: usize| highest_patch_number.max(patch_number))
-            .or(Some(patch_number));
         self.save_patches_state()
     }
 
@@ -452,12 +450,13 @@ impl ManagePatches for PatchManager {
 
     fn record_boot_failure_for_patch(&mut self, patch_number: usize) -> Result<()> {
         self.patches_state.currently_booting_patch = None;
+        self.patches_state.known_bad_patches.insert(patch_number);
         self.try_fall_back_from_patch(patch_number);
         self.save_patches_state()
     }
 
-    fn highest_seen_patch_number(&self) -> Option<usize> {
-        self.patches_state.highest_seen_patch_number
+    fn is_known_bad_patch(&self, patch_number: usize) -> bool {
+        self.patches_state.known_bad_patches.contains(&patch_number)
     }
 
     fn reset(&mut self) -> Result<()> {
@@ -523,7 +522,7 @@ mod debug_tests {
         let temp_dir = TempDir::new("patch_manager").unwrap();
         let patch_manager = PatchManager::new(temp_dir.path().to_owned(), Some("public_key"));
         let expected_str = format!(
-            "PatchManager {{ root_dir: \"{}\", patches_state: PatchesState {{ last_booted_patch: None, next_boot_patch: None, currently_booting_patch: None, highest_seen_patch_number: None }}, patch_public_key: Some(\"public_key\") }}",
+            "PatchManager {{ root_dir: \"{}\", patches_state: PatchesState {{ last_booted_patch: None, next_boot_patch: None, currently_booting_patch: None, known_bad_patches: {{}} }}, patch_public_key: Some(\"public_key\") }}",
             temp_dir.path().display()
         );
         assert_eq!(format!("{:?}", patch_manager), expected_str);
@@ -620,36 +619,6 @@ mod add_patch_tests {
             })
         );
         assert!(!file_path.exists());
-        assert_eq!(manager.highest_seen_patch_number(), Some(patch_number));
-    }
-
-    #[test]
-    fn does_not_set_higher_highest_seen_patch_number_if_added_patch_is_lower() -> Result<()> {
-        let patch_file_contents = "patch contents";
-
-        let temp_dir = TempDir::new("patch_manager")?;
-        let mut manager = PatchManager::manager_for_test(&temp_dir);
-        assert!(manager.highest_seen_patch_number().is_none());
-
-        // Add patch 1
-        let file_path = &temp_dir.path().join("patch.vmcode");
-        std::fs::write(file_path, patch_file_contents)?;
-        assert!(manager.add_patch(1, file_path, "hash", None).is_ok());
-        assert_eq!(manager.highest_seen_patch_number(), Some(1));
-
-        // Add patch 4, expect 4 to be the highest patch number we've seen
-        let file_path = &temp_dir.path().join("patch.vmcode");
-        std::fs::write(file_path, patch_file_contents)?;
-        assert!(manager.add_patch(4, file_path, "hash", None).is_ok());
-        assert_eq!(manager.highest_seen_patch_number(), Some(4));
-
-        // Add patch 3, expect 4 to still be the highest patch number we've seen
-        let file_path = &temp_dir.path().join("patch.vmcode");
-        std::fs::write(file_path, patch_file_contents)?;
-        assert!(manager.add_patch(3, file_path, "hash", None).is_ok());
-        assert_eq!(manager.highest_seen_patch_number(), Some(4));
-
-        Ok(())
     }
 }
 
@@ -1231,6 +1200,7 @@ mod record_boot_failure_for_patch_tests {
         manager.add_patch_for_test(&temp_dir, 1)?;
         assert!(manager.record_boot_start_for_patch(1).is_ok());
         assert!(manager.record_boot_success().is_ok());
+        assert!(!manager.is_known_bad_patch(1));
         let succeeded_patch_artifact_path = manager.patch_artifact_path(1);
 
         manager.add_patch_for_test(&temp_dir, 2)?;
@@ -1243,6 +1213,7 @@ mod record_boot_failure_for_patch_tests {
         assert!(manager.record_boot_start_for_patch(2).is_ok());
         assert!(manager.record_boot_failure_for_patch(2).is_ok());
         assert!(!failed_patch_artifact_path.exists());
+        assert!(manager.is_known_bad_patch(2));
 
         Ok(())
     }
@@ -1266,28 +1237,8 @@ mod record_boot_failure_for_patch_tests {
         assert!(manager.record_boot_failure_for_patch(1).is_ok());
         assert!(manager.last_successfully_booted_patch().is_none());
         assert!(manager.next_boot_patch().is_none());
+        assert!(manager.is_known_bad_patch(1));
         assert!(!patch_artifact_path.exists());
-
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod highest_seen_patch_number_tests {
-    use super::*;
-    use anyhow::{Ok, Result};
-    use tempdir::TempDir;
-
-    #[test]
-    fn returns_value_from_internal_state() -> Result<()> {
-        let temp_dir = TempDir::new("patch_manager")?;
-        let mut manager = PatchManager::manager_for_test(&temp_dir);
-
-        assert!(manager.patches_state.highest_seen_patch_number.is_none());
-        assert!(manager.highest_seen_patch_number().is_none());
-
-        manager.patches_state.highest_seen_patch_number = Some(1);
-        assert_eq!(manager.highest_seen_patch_number(), Some(1));
 
         Ok(())
     }

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -173,14 +173,12 @@ pub struct PatchCheckRequest {
     /// running.  Patches are keyed to release versions and will only be
     /// offered to clients running the same release version.
     pub release_version: String,
-    /// The latest patch number that the client has downloaded.
-    /// Not necessarily the one it's running (if some have been marked bad).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub patch_number: Option<usize>,
     /// Platform (e.g. "android", "ios", "windows", "macos", "linux").
     pub platform: String,
     /// Architecture we're running (e.g. "aarch64", "x86", "x86_64").
     pub arch: String,
+    // We specifically do not send a patch number as part of this request because we always want to
+    // know what the latest available patch is.
 }
 
 /// The request body for the create patch install event endpoint.
@@ -290,7 +288,6 @@ mod tests {
                 app_id: "".to_string(),
                 channel: "".to_string(),
                 release_version: "".to_string(),
-                patch_number: None,
                 platform: "".to_string(),
                 arch: "".to_string(),
             },

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -226,9 +226,6 @@ fn patch_check_request(config: &UpdateConfig) -> PatchCheckRequest {
         app_id: config.app_id.clone(),
         channel: config.channel.clone(),
         release_version: config.release_version.clone(),
-        // Don't report a patch number to ensure we receive the latest patch.
-        // We will determine during the update process if an available patch should be installed.
-        patch_number: None,
         platform: current_platform().to_string(),
         arch: current_arch().to_string(),
     }

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -50,7 +50,10 @@ impl Display for UpdateStatus {
     }
 }
 
-/// Returned when a call to `init` is not successful.
+/// Returned when a call to `init` is not successful. These indicate that the specific call to
+/// `init` was not successful, but the library may still be in a valid state (e.g., if
+/// `AlreadyInitialized` is returned, the library is still initialized). Callers can safely ignore
+/// these errors if they are not interested in the specific reason why `init` failed.
 #[derive(Debug, PartialEq)]
 pub enum InitError {
     InvalidArgument(String, String),

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -30,10 +30,12 @@ pub use crate::config::testing_reset_config;
 #[cfg(test)]
 pub use crate::network::{DownloadFileFn, Patch, PatchCheckRequestFn};
 
+#[derive(Debug, PartialEq)]
 pub enum UpdateStatus {
     NoUpdate,
     UpdateInstalled,
     UpdateHadError,
+    UpdateIsBadPatch,
 }
 
 impl Display for UpdateStatus {
@@ -42,6 +44,10 @@ impl Display for UpdateStatus {
             UpdateStatus::NoUpdate => write!(f, "No update"),
             UpdateStatus::UpdateInstalled => write!(f, "Update installed"),
             UpdateStatus::UpdateHadError => write!(f, "Update had error"),
+            UpdateStatus::UpdateIsBadPatch => write!(
+                f,
+                "Update available but previously failed to install. Not installing."
+            ),
         }
     }
 }
@@ -177,8 +183,8 @@ pub fn should_auto_update() -> anyhow::Result<bool> {
     with_config(|config| Ok(config.auto_update))
 }
 
-fn patch_check_request(config: &UpdateConfig, state: &UpdaterState) -> PatchCheckRequest {
-    let latest_patch_number = state.latest_seen_patch_number();
+fn patch_check_request(config: &UpdateConfig, state: &mut UpdaterState) -> PatchCheckRequest {
+    let latest_patch_number = state.next_boot_patch().map(|p| p.number);
 
     // Send the request to the server.
     PatchCheckRequest {
@@ -195,7 +201,7 @@ fn check_for_update_internal() -> anyhow::Result<PatchCheckResponse> {
     let (request, url, request_fn) = with_config(|config| {
         // Load UpdaterState from disk
         // If there is no state, make an empty state.
-        let state = UpdaterState::load_or_new_on_error(
+        let mut state = UpdaterState::load_or_new_on_error(
             &config.storage_dir,
             &config.release_version,
             config.patch_public_key.as_deref(),
@@ -203,7 +209,7 @@ fn check_for_update_internal() -> anyhow::Result<PatchCheckResponse> {
 
         // Get the required info to make the request.
         Ok((
-            patch_check_request(config, &state),
+            patch_check_request(config, &mut state),
             patches_check_url(&config.base_url),
             config.network_hooks.patch_check_request_fn,
         ))
@@ -309,7 +315,7 @@ fn update_internal(_: &UpdaterLockState) -> anyhow::Result<UpdateStatus> {
         }
     }
     // We're abusing the config lock as a UpdateState lock for now.
-    let read_only_state = with_config(|_| {
+    let mut state = with_config(|_| {
         let mut state = UpdaterState::load_or_new_on_error(
             &config.storage_dir,
             &config.release_version,
@@ -326,7 +332,7 @@ fn update_internal(_: &UpdaterLockState) -> anyhow::Result<UpdateStatus> {
     })?;
 
     // Check for update.
-    let request = patch_check_request(&config, &read_only_state);
+    let request = patch_check_request(&config, &mut state);
     let patch_check_request_fn = &(config.network_hooks.patch_check_request_fn);
     let response = patch_check_request_fn(&patches_check_url(&config.base_url), request)?;
     if !response.patch_available {
@@ -334,6 +340,13 @@ fn update_internal(_: &UpdaterLockState) -> anyhow::Result<UpdateStatus> {
     }
 
     let patch = response.patch.ok_or(UpdateError::BadServerResponse)?;
+    if state.is_known_bad_patch(patch.number) {
+        info!(
+            "Patch {} has previously failed to boot, skipping.",
+            patch.number
+        );
+        return Ok(UpdateStatus::UpdateIsBadPatch);
+    }
 
     let download_dir = PathBuf::from(&config.download_dir);
     let download_path = download_dir.join(patch.number.to_string());
@@ -593,6 +606,7 @@ mod tests {
     use tempdir::TempDir;
 
     use crate::{
+        cache::UpdaterState,
         config::{testing_reset_config, with_config},
         network::{testing_set_network_hooks, NetworkHooks, PatchCheckResponse},
         time, ExternalFileProvider,
@@ -914,6 +928,52 @@ mod tests {
             Ok(())
         })
         .unwrap();
+    }
+
+    #[serial]
+    #[test]
+    fn does_not_download_known_bad_patch() -> anyhow::Result<()> {
+        let mut server = mockito::Server::new();
+        let check_response = PatchCheckResponse {
+            patch_available: true,
+            patch: Some(crate::network::Patch {
+                number: 1,
+                download_url: "download_url".to_string(),
+                hash: "hash".to_string(),
+                hash_signature: None,
+            }),
+        };
+        let check_response_body = serde_json::to_string(&check_response).unwrap();
+        let _ = server
+            .mock("POST", "/api/v1/patches/check")
+            .with_status(200)
+            .with_body(check_response_body)
+            .create();
+        let tmp_dir = TempDir::new("example").unwrap();
+        init_for_testing(&tmp_dir, Some(&server.url()));
+
+        let mut updater_state = with_config(|config| {
+            let mut state = UpdaterState::load_or_new_on_error(
+                &config.storage_dir,
+                &config.release_version,
+                config.patch_public_key.as_deref(),
+            );
+
+            state.record_boot_failure_for_patch(1)?;
+
+            Ok(state)
+        })?;
+
+        // Make sure we're starting with no next boot patch.
+        assert!(updater_state.next_boot_patch().is_none());
+
+        let result = super::update()?;
+
+        // Ensure that we've skipped the known bad patch.
+        assert_eq!(result, crate::UpdateStatus::UpdateIsBadPatch);
+        assert!(updater_state.next_boot_patch().is_none());
+
+        Ok(())
     }
 
     #[serial]


### PR DESCRIPTION
## Description

Updates our patch check logic to:

- Record patch numbers that fail to boot in a list of "known bad" patches.
- When making a patch check request, don't send a patch number. Instead, if there is a patch available for download, check whether we currently have the patch installed and ignore the new patch if so.
- If the server responds with a patch number that we have marked bad, do not attempt to download or install it.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
