### PR TITLE
feat: add rollback support

### DIFF
--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -283,7 +283,7 @@ mod test {
     use super::*;
     use crate::{
         network::{testing_set_network_hooks, PatchCheckResponse},
-        test_utils::write_fake_zip,
+        test_utils::write_fake_apk,
     };
     use anyhow::Ok;
     use serial_test::serial;
@@ -451,7 +451,7 @@ mod test {
         let base = "hello world";
         let expected_new: &str = "hello tests";
         let apk_path = tmp_dir.path().join("base.apk");
-        write_fake_zip(apk_path.to_str().unwrap(), base.as_bytes());
+        write_fake_apk(apk_path.to_str().unwrap(), base.as_bytes());
         let fake_libapp_path = tmp_dir.path().join("lib/arch/ignored.so");
         let c_params = parameters(&tmp_dir, fake_libapp_path.to_str().unwrap());
         // app_id is required or shorebird_init will fail.

--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -281,7 +281,10 @@ pub extern "C" fn shorebird_report_launch_success() {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::network::{testing_set_network_hooks, PatchCheckResponse};
+    use crate::{
+        network::{testing_set_network_hooks, PatchCheckResponse},
+        test_utils::write_fake_zip,
+    };
     use anyhow::Ok;
     use serial_test::serial;
     use tempdir::TempDir;
@@ -436,18 +439,6 @@ mod test {
         shorebird_report_launch_start();
         shorebird_report_launch_success();
         shorebird_report_launch_failure();
-    }
-
-    fn write_fake_zip(zip_path: &str, libapp_contents: &[u8]) {
-        use std::io::Write;
-        let mut zip = zip::ZipWriter::new(std::fs::File::create(zip_path).unwrap());
-        let options = zip::write::FileOptions::default()
-            .compression_method(zip::CompressionMethod::Stored)
-            .unix_permissions(0o755);
-        let app_path = crate::android::get_relative_lib_path("libapp.so");
-        zip.start_file(app_path.to_str().unwrap(), options).unwrap();
-        zip.write_all(libapp_contents).unwrap();
-        zip.finish().unwrap();
     }
 
     #[serial]

--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -482,6 +482,7 @@ mod test {
                         download_url: "ignored".to_owned(),
                         hash_signature: None,
                     }),
+                    rolled_back_patch_numbers: None,
                 })
             },
             |_url| {
@@ -584,6 +585,7 @@ mod test {
                         download_url: "ignored".to_owned(),
                         hash_signature: None,
                     }),
+                    rolled_back_patch_numbers: None,
                 })
             },
             |_url| {

--- a/library/src/cache/updater_state.rs
+++ b/library/src/cache/updater_state.rs
@@ -199,6 +199,12 @@ impl UpdaterState {
             .add_patch(patch.number, &patch.path, hash, signature)
     }
 
+    /// Removes the artifacts for patch `patch_number` from disk and updates state to ensure the
+    /// uninstalled patch is not booted in the future.
+    pub fn uninstall_patch(&mut self, patch_number: usize) -> Result<()> {
+        self.patch_manager.remove_patch(patch_number)
+    }
+
     /// Returns true if we have previously failed to boot from patch `patch_number`.
     pub fn is_known_bad_patch(&self, patch_number: usize) -> bool {
         self.patch_manager.is_known_bad_patch(patch_number)

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -19,6 +19,9 @@ mod yaml;
 #[cfg(any(target_os = "android", test))]
 mod android;
 
+#[cfg(test)]
+mod test_utils;
+
 // Take all public items from the updater namespace and make them public.
 pub use self::updater::*;
 

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -190,13 +190,20 @@ pub struct CreatePatchEventRequest {
     event: PatchEvent,
 }
 
+/// A response from the server telling us the latest state of patches for this release.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PatchCheckResponse {
     pub patch_available: bool,
     #[serde(default)]
     pub patch: Option<Patch>,
+
+    /// A list of patch numbers that have been rolled back by app developers. These should be
+    /// uninstalled from the device and not booted from.
+    #[serde(default)]
+    pub rolled_back_patch_numbers: Option<Vec<usize>>,
 }
 
+/// Reports a patch event (e.g., install success/failure) to the server.
 pub fn send_patch_event(event: PatchEvent, config: &UpdateConfig) -> anyhow::Result<()> {
     let request = CreatePatchEventRequest { event };
 
@@ -205,6 +212,7 @@ pub fn send_patch_event(event: PatchEvent, config: &UpdateConfig) -> anyhow::Res
     report_event_fn(url, request)
 }
 
+/// Downloads the file at `url` to `path`.
 pub fn download_to_path(
     network_hooks: &NetworkHooks,
     url: &str,

--- a/library/src/test_utils.rs
+++ b/library/src/test_utils.rs
@@ -35,9 +35,8 @@ pub fn install_fake_patch(patch_number: usize) -> anyhow::Result<()> {
 pub fn write_fake_apk(apk_path: &str, libapp_contents: &[u8]) {
     use std::io::Write;
     let mut zip = zip::ZipWriter::new(std::fs::File::create(apk_path).unwrap());
-    let options = zip::write::FileOptions::default()
-        .compression_method(zip::CompressionMethod::Stored)
-        .unix_permissions(0o755);
+    let options =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
     let app_path = crate::android::get_relative_lib_path("libapp.so");
     zip.start_file(app_path.to_str().unwrap(), options).unwrap();
     zip.write_all(libapp_contents).unwrap();

--- a/library/src/test_utils.rs
+++ b/library/src/test_utils.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+use crate::{
+    cache::{PatchInfo, UpdaterState},
+    config::with_config,
+};
+
+pub fn install_fake_patch(patch_number: usize) -> anyhow::Result<()> {
+    with_config(|config| {
+        let download_dir = std::path::PathBuf::from(&config.download_dir);
+        let artifact_path = download_dir.join(patch_number.to_string());
+        fs::create_dir_all(&download_dir)?;
+        fs::write(&artifact_path, "hello")?;
+
+        let mut state = UpdaterState::load_or_new_on_error(
+            &config.storage_dir,
+            &config.release_version,
+            config.patch_public_key.as_deref(),
+        );
+        state.install_patch(
+            &PatchInfo {
+                path: artifact_path,
+                number: patch_number,
+            },
+            "hash",
+            None,
+        )?;
+        state.save()
+    })
+}
+
+pub fn write_fake_zip(zip_path: &str, libapp_contents: &[u8]) {
+    use std::io::Write;
+    let mut zip = zip::ZipWriter::new(std::fs::File::create(zip_path).unwrap());
+    let options = zip::write::FileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored)
+        .unix_permissions(0o755);
+    let app_path = crate::android::get_relative_lib_path("libapp.so");
+    zip.start_file(app_path.to_str().unwrap(), options).unwrap();
+    zip.write_all(libapp_contents).unwrap();
+    zip.finish().unwrap();
+}

--- a/library/src/test_utils.rs
+++ b/library/src/test_utils.rs
@@ -1,3 +1,4 @@
+/// Helper methods for tests.
 use std::fs;
 
 use crate::{
@@ -5,6 +6,7 @@ use crate::{
     config::with_config,
 };
 
+/// Writes a fake patch to the patches directory and sets it as the next boot patch.
 pub fn install_fake_patch(patch_number: usize) -> anyhow::Result<()> {
     with_config(|config| {
         let download_dir = std::path::PathBuf::from(&config.download_dir);
@@ -29,9 +31,10 @@ pub fn install_fake_patch(patch_number: usize) -> anyhow::Result<()> {
     })
 }
 
-pub fn write_fake_zip(zip_path: &str, libapp_contents: &[u8]) {
+/// Creates a fake APK at `apk_path` and writes `libapp_contents` to its relative `libapp.so` path.
+pub fn write_fake_apk(apk_path: &str, libapp_contents: &[u8]) {
     use std::io::Write;
-    let mut zip = zip::ZipWriter::new(std::fs::File::create(zip_path).unwrap());
+    let mut zip = zip::ZipWriter::new(std::fs::File::create(apk_path).unwrap());
     let options = zip::write::FileOptions::default()
         .compression_method(zip::CompressionMethod::Stored)
         .unix_permissions(0o755);

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -103,7 +103,7 @@ impl Display for UpdateError {
     }
 }
 
-// `AppConfig` is the rust API.  `ResolvedConfig` is the internal storage.
+// `AppConfig` is the rust API.
 // However rusty api would probably used `&str` instead of `String`,
 // but making `&str` from `CStr*` is a bit of a pain.
 pub struct AppConfig {
@@ -1144,7 +1144,7 @@ mod rollback_tests {
 
     use crate::{
         network::PatchCheckResponse,
-        test_utils::{install_fake_patch, write_fake_zip},
+        test_utils::{install_fake_patch, write_fake_apk},
     };
 
     use super::{
@@ -1266,7 +1266,7 @@ mod rollback_tests {
         // Install the base apk to allow the "downloaded" patch 1 to successfully inflate and install.
         let base = "hello world";
         let apk_path = tmp_dir.path().join("base.apk");
-        write_fake_zip(apk_path.to_str().unwrap(), base.as_bytes());
+        write_fake_apk(apk_path.to_str().unwrap(), base.as_bytes());
 
         // Install patch 2, pretend we're starting to boot from it, but don't report success or failure
         // to ensure we still have patch 1 on disk.

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -360,11 +360,11 @@ fn update_internal(_: &UpdaterLockState) -> anyhow::Result<UpdateStatus> {
     // Check for update.
     let patch_check_request_fn = &(config.network_hooks.patch_check_request_fn);
     let response = patch_check_request_fn(&patches_check_url(&config.base_url), request)?;
+    info!("Patch check response: {:?}", response);
 
     with_mut_state(|state| {
         if let Some(rolled_back_patches) = response.rolled_back_patch_numbers {
             if !rolled_back_patches.is_empty() {
-                info!("Rolled back patches: {:?}", rolled_back_patches);
                 for patch_number in rolled_back_patches {
                     info!("Attempting uninstall of patch {}...", patch_number);
                     state.uninstall_patch(patch_number)?;


### PR DESCRIPTION
## Description

Adds rollback support.

If the response to a patch check request tells us there are rolled back patches, delete them and ensure we don't try to boot from them in the future.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
