### PR TITLE
feat: add message to patch event

### DIFF
--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -69,11 +69,19 @@ pub struct PatchEvent {
 
     /// When this event occurred as a Unix epoch timestamp in seconds.
     pub timestamp: u64,
+
+    /// An optional message to be sent with the event.
+    pub message: Option<String>,
 }
 
 impl PatchEvent {
     /// Creates a `PatchEvent` for the given `EventType` and patch number for reporting to the server.
-    pub fn new(config: &UpdateConfig, event_type: EventType, patch_number: usize) -> PatchEvent {
+    pub fn new(
+        config: &UpdateConfig,
+        event_type: EventType,
+        patch_number: usize,
+        message: Option<&str>,
+    ) -> PatchEvent {
         PatchEvent {
             app_id: config.app_id.clone(),
             arch: current_arch().to_string(),
@@ -82,6 +90,7 @@ impl PatchEvent {
             platform: current_platform().to_string(),
             release_version: config.release_version.clone(),
             timestamp: time::unix_timestamp(),
+            message: message.map(|s| s.to_string()),
         }
     }
 }

--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -71,6 +71,7 @@ pub struct PatchEvent {
     pub timestamp: u64,
 
     /// An optional message to be sent with the event.
+    /// Care should be taken that this field *never* contain PII or sensitive information.
     pub message: Option<String>,
 }
 

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -287,12 +287,33 @@ mod tests {
             release_version: "release_version".to_string(),
             identifier: EventType::PatchInstallSuccess,
             timestamp: 1234,
+            message: None,
         };
         let request = super::CreatePatchEventRequest { event };
         let json_string = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json_string,
-            r#"{"event":{"app_id":"app_id","arch":"arch","type":"__patch_install__","patch_number":1,"platform":"platform","release_version":"release_version","timestamp":1234}}"#
+            r#"{"event":{"app_id":"app_id","arch":"arch","type":"__patch_install__","patch_number":1,"platform":"platform","release_version":"release_version","timestamp":1234,"message":null}}"#
+        )
+    }
+
+    #[test]
+    fn create_patch_install_event_request_serializes_with_message() {
+        let event = PatchEvent {
+            app_id: "app_id".to_string(),
+            arch: "arch".to_string(),
+            patch_number: 1,
+            platform: "platform".to_string(),
+            release_version: "release_version".to_string(),
+            identifier: EventType::PatchInstallSuccess,
+            timestamp: 1234,
+            message: Some("hello".to_string()),
+        };
+        let request = super::CreatePatchEventRequest { event };
+        let json_string = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            json_string,
+            r#"{"event":{"app_id":"app_id","arch":"arch","type":"__patch_install__","patch_number":1,"platform":"platform","release_version":"release_version","timestamp":1234,"message":"hello"}}"#
         )
     }
 
@@ -367,6 +388,7 @@ mod tests {
             release_version: "release_version".to_string(),
             identifier: EventType::PatchInstallSuccess,
             timestamp: time::unix_timestamp(),
+            message: None,
         };
         let result = super::report_event_default(
             // Make the request to a non-existent URL, which will trigger the
@@ -395,6 +417,7 @@ mod tests {
                     release_version: "release_version".to_string(),
                     identifier: EventType::PatchInstallSuccess,
                     timestamp: time::unix_timestamp(),
+                    message: None,
                 },
             },
         );


### PR DESCRIPTION
## Description

Adds an optional `message` field to the PatchEvent object.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
