### PR TITLE
fix: increase minimum flutter version to 3.24.5

### DIFF
--- a/shorebird_code_push/pubspec.yaml
+++ b/shorebird_code_push/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/shorebirdtech/updater/tree/main/shorebird_code_pu
 
 environment:
   sdk: ">=3.5.4 <4.0.0"
-  flutter: ">=3.24.4"
+  flutter: ">=3.24.5"
 
 dependencies:
   ffi: ^2.0.2


### PR DESCRIPTION
The changes in 2.0.0 do not exist in Flutter 3.24.4, so we should only allow for Flutter 3.24.5 and above.

Fixes https://github.com/shorebirdtech/shorebird/issues/2628