### PR TITLE
fix: build updater with static runtime to prevent flutter engine build linking errors

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,9 +1,9 @@
 $schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
-version: '0.2'
+version: "0.2"
 ignorePaths:
   - target
   - build
-  - '**/*.g.dart'
+  - "**/*.g.dart"
   # Flutter platform directories with per-platform build files
   - windows
   - macos
@@ -47,11 +47,13 @@ words:
   - logcat
   - mockall
   - mocktail
+  - msvc
   - oslog
   - pubspec
   - repr
   - reqwest
   - rollouts
+  - rustflags
   - rustls
   - rustup
   - serde

--- a/library/.cargo/config.toml
+++ b/library/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Prevents missing DLLs when running the binary on Windows
+# See https://github.com/shorebirdtech/shorebird/issues/1487
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
We currently do this for patch. Without this flag, the updater failed to link into the Flutter engine with the following:

```
...
b"LINK : warning LNK4217: symbol 'qsort' defined in 'libucrt.lib(qsort.obj)' is imported by 'updater.lib(cover.o)' in function 'COVER_ctx_init'\r\n"
b'updater.lib(std-b84ff5acd6bc244a.std.bacbcc9a321ad2c6-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp_GetUserProfileDirectoryW referenced in function _ZN3std3env8home_dir17h0161835f45803d72E\r\n'
b'updater.lib(zdict.o) : error LNK2019: unresolved external symbol __imp_clock referenced in function ZDICT_clockSpan\r\n'
b'updater.lib(fastcover.o) : error LNK2001: unresolved external symbol __imp_clock\r\n'
b'updater.lib(cover.o) : error LNK2001: unresolved external symbol __imp_clock\r\n'
b'updater.lib(divsufsort.o) : error LNK2019: unresolved external symbol __imp__wassert referenced in function construct_BWT\r\n'
b'.\\flutter_windows.dll : fatal error LNK1120: 3 unresolved externals\r\n'
ninja: build stopped: subcommand failed.
```