### PR TITLE
feat: add windows support

### DIFF
--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -320,7 +320,15 @@ fn patch_base(config: &UpdateConfig) -> anyhow::Result<Box<dyn ReadSeek>> {
     Ok(Box::new(base_r))
 }
 
-#[cfg(not(any(target_os = "android", test)))]
+#[cfg(all(target_os = "windows", not(test)))]
+fn patch_base(config: &UpdateConfig) -> anyhow::Result<Box<dyn ReadSeek>> {
+    let mut buffer = Vec::new();
+    let mut file = fs::File::open(&config.libapp_path)?;
+    file.read_to_end(&mut buffer)?;
+    Ok(Box::new(Cursor::new(buffer)))
+}
+
+#[cfg(not(any(target_os = "android", target_os = "windows", test)))]
 fn patch_base(config: &UpdateConfig) -> anyhow::Result<Box<dyn ReadSeek>> {
     config.file_provider.open()
 }

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -313,6 +313,7 @@ fn check_hash(path: &Path, expected_string: &str) -> anyhow::Result<()> {
 }
 
 impl ReadSeek for Cursor<Vec<u8>> {}
+impl ReadSeek for fs::File {}
 
 #[cfg(any(target_os = "android", test))]
 fn patch_base(config: &UpdateConfig) -> anyhow::Result<Box<dyn ReadSeek>> {
@@ -322,10 +323,8 @@ fn patch_base(config: &UpdateConfig) -> anyhow::Result<Box<dyn ReadSeek>> {
 
 #[cfg(all(target_os = "windows", not(test)))]
 fn patch_base(config: &UpdateConfig) -> anyhow::Result<Box<dyn ReadSeek>> {
-    let mut buffer = Vec::new();
-    let mut file = fs::File::open(&config.libapp_path)?;
-    file.read_to_end(&mut buffer)?;
-    Ok(Box::new(Cursor::new(buffer)))
+    let file = fs::File::open(&config.libapp_path)?;
+    Ok(Box::new(file))
 }
 
 #[cfg(not(any(target_os = "android", target_os = "windows", test)))]


### PR DESCRIPTION
## Description

Because windows works just like Android, and because Windows doesn't have to root around in the app bundle to find a libapp.so, we need to provide a platform-specific patch_base function.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
