### PR TITLE
feat(shorebird_code_push): override `toString` in exceptions

### DIFF
--- a/shorebird_code_push/lib/src/shorebird_updater.dart
+++ b/shorebird_code_push/lib/src/shorebird_updater.dart
@@ -28,9 +28,7 @@ class ReadPatchException implements Exception {
   final String message;
 
   @override
-  String toString() {
-    return '[ShorebirdUpdater.ReadPatchException] $message';
-  }
+  String toString() => '[ShorebirdUpdater] ReadPatchException: $message';
 }
 
 /// {@template update_exception}
@@ -49,7 +47,7 @@ class UpdateException implements Exception {
 
   @override
   String toString() {
-    return '[ShorebirdUpdater.UpdateException] $message';
+    return '[ShorebirdUpdater] UpdateException: $message (${reason.name})';
   }
 }
 

--- a/shorebird_code_push/lib/src/shorebird_updater.dart
+++ b/shorebird_code_push/lib/src/shorebird_updater.dart
@@ -26,6 +26,11 @@ class ReadPatchException implements Exception {
 
   /// The human-readable error message.
   final String message;
+
+  @override
+  String toString() {
+    return '[ShorebirdUpdater.ReadPatchException] $message';
+  }
 }
 
 /// {@template update_exception}
@@ -41,6 +46,11 @@ class UpdateException implements Exception {
 
   /// The reason the update failed.
   final UpdateFailureReason reason;
+
+  @override
+  String toString() {
+    return '[ShorebirdUpdater.UpdateException] $message';
+  }
 }
 
 /// Log message when the Shorebird updater is unavailable in the current

--- a/shorebird_code_push/test/src/shorebird_updater_test.dart
+++ b/shorebird_code_push/test/src/shorebird_updater_test.dart
@@ -11,5 +11,30 @@ void main() {
         expect(ShorebirdUpdater.new, returnsNormally);
       }),
     );
+
+    group(UpdateException, () {
+      test('overrides toString', () {
+        const message = 'message';
+        const reason = UpdateFailureReason.downloadFailed;
+        const exception = UpdateException(message: message, reason: reason);
+        expect(
+          exception.toString(),
+          equals(
+            '[ShorebirdUpdater] UpdateException: $message (${reason.name})',
+          ),
+        );
+      });
+    });
+
+    group(ReadPatchException, () {
+      test('overrides toString', () {
+        const message = 'message';
+        const exception = ReadPatchException(message: message);
+        expect(
+          exception.toString(),
+          equals('[ShorebirdUpdater] ReadPatchException: $message'),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
Override toString() in `ReadPatchException` and `UpdateException` classes as pointed out in (#253 ). 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
