### PR TITLE
fix: separate validation checks from next_boot_patch getter

### DIFF
--- a/library/include/updater.h
+++ b/library/include/updater.h
@@ -134,6 +134,14 @@ SHOREBIRD_EXPORT uintptr_t shorebird_current_boot_patch_number(void);
 SHOREBIRD_EXPORT uintptr_t shorebird_next_boot_patch_number(void);
 
 /**
+ * Performs integrity checks on the next boot patch. If the patch fails these checks, the patch
+ * will be deleted and the next boot patch will be set to the last successfully booted patch or
+ * the base release if there is no last successfully booted patch.
+ */
+SHOREBIRD_EXPORT
+void shorebird_validate_next_boot_patch(void);
+
+/**
  * The path to the patch that will boot on the next run of the app, or NULL if
  * there is no next patch.
  */

--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -231,6 +231,18 @@ fn to_update_result(status: anyhow::Result<UpdateStatus>) -> UpdateResult {
     return result;
 }
 
+/// Performs integrity checks on the next boot patch. If the patch fails these checks, the patch
+/// will be deleted and the next boot patch will be set to the last successfully booted patch or
+/// the base release if there is no last successfully booted patch.
+#[no_mangle]
+pub extern "C" fn shorebird_validate_next_boot_patch() {
+    log_on_error(
+        || updater::validate_next_boot_patch(),
+        "validating next_boot_patch",
+        (),
+    );
+}
+
 /// The path to the patch that will boot on the next run of the app, or NULL if
 /// there is no next patch.
 #[no_mangle]

--- a/library/src/cache/updater_state.rs
+++ b/library/src/cache/updater_state.rs
@@ -193,6 +193,15 @@ impl UpdaterState {
         self.patch_manager.next_boot_patch()
     }
 
+    /// Performs integrity checks on the next boot patch. If the patch fails these checks, the patch
+    /// will be deleted and the next boot patch will be set to the last successfully booted patch or
+    /// the base release if there is no last successfully booted patch.
+    ///
+    /// Returns an error if the patch fails integrity checks.
+    pub fn validate_next_boot_patch(&mut self) -> anyhow::Result<()> {
+        self.patch_manager.validate_next_boot_patch()
+    }
+
     /// Copies the patch file at file_path to the manager's directory structure sets
     /// this patch as the next patch to boot.
     pub fn install_patch(

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -538,6 +538,15 @@ where
     Ok(())
 }
 
+/// Performs integrity checks on the next boot patch. If the patch fails these checks, the patch
+/// will be deleted and the next boot patch will be set to the last successfully booted patch or
+/// the base release if there is no last successfully booted patch.
+///
+/// Returns an error if the patch fails integrity checks.
+pub fn validate_next_boot_patch() -> anyhow::Result<()> {
+    with_mut_state(|state| state.validate_next_boot_patch())
+}
+
 /// The patch which will be run on next boot (which may still be the same
 /// as the current boot).
 /// This may be changed any time by:


### PR DESCRIPTION
## Description

Moves the validation in `next_boot_patch` to a separate `validate_next_boot_patch` function.

Fixes https://github.com/shorebirdtech/updater/issues/296

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
