### PR TITLE
ci: build patch binary for aarch64-apple-darwin

### DIFF
--- a/.github/workflows/build_patch_artifacts.yaml
+++ b/.github/workflows/build_patch_artifacts.yaml
@@ -14,7 +14,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-          - os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
           - os: windows-latest
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Part of https://github.com/shorebirdtech/shorebird/issues/3410

## Summary
- Add explicit \`x86_64-apple-darwin\` and \`aarch64-apple-darwin\` matrix entries to \`build_patch_artifacts.yaml\` so each release produces both Intel and Apple Silicon macOS binaries.
- The previous macOS job relied on the runner default target, producing only one architecture (whichever matched \`macos-latest\`). Apple Silicon users with no Rosetta were hitting \`ProcessException: Bad CPU type in executable\` when the CLI invoked the downloaded \`patch\` binary.

## Test plan
- [ ] Cut a new \`patch-v*\` release and verify both \`patch-x86_64-apple-darwin.zip\` and \`patch-aarch64-apple-darwin.zip\` are uploaded as release assets.
- [ ] \`file\` the extracted binaries to confirm architectures.