### PR TITLE
perf: set panic=abort and drop backtrace features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,21 +111,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "base64"
@@ -639,12 +615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,7 +964,6 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
 dependencies = [
- "backtrace",
  "log",
 ]
 
@@ -1104,15 +1073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1389,12 +1349,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 strip = "debuginfo"
+panic = "abort"

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 # Used for error handling for now.
-anyhow = { version = "1.0.69", features = ["backtrace"] }
+anyhow = "1.0.69"
 base64 = "0.22.0"
 # For inflating compressed patch files.
 bipatch = "1.0.0"
@@ -50,11 +50,11 @@ zip = { version = "8.5.1", default-features = false, features = ["deflate"] }
 # For logging to Android logcat.
 android_logger = "0.15.0"
 # Send panics to log (instead of stderr), thus logcat on Android.
-log-panics = { version = "2", features = ["with-backtrace"] }
+log-panics = "2"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 # Send panics to syslog (instead of stderr).
-log-panics = { version = "2", features = ["with-backtrace"] }
+log-panics = "2"
 # Support for logging on iOS (https://developer.apple.com/documentation/oslog)
 oslog = "0.2.0"
 


### PR DESCRIPTION
## Summary

Reduces binary size of the updater when linked into the Flutter engine by eliminating panic-unwinding metadata and backtrace-symbolication machinery that we can't surface to end users anyway.

**Measured on host macOS arm64 (`libupdater.dylib`):**
- File size: 3.07 MB → 2.56 MB (**-520 KB**)
- `.text` section: 1.2 MB → 1.1 MB
- Gone from top crates: `gimli`, `addr2line`, `rustc_demangle`

Expected iOS savings are larger because `panic=abort` eliminates the `__eh_frame` / `__gcc_except_tab` / `__unwind_info` growth that dominates Shorebird's iOS framework overhead vs. upstream Flutter.

## Changes

- `panic = "abort"` in `[profile.release]`. We don't use `catch_unwind` anywhere in the library, so losing unwinding costs nothing behavioral. `log-panics` still runs its panic hook before abort, so panic messages continue to surface to logcat/oslog during development.
- Drop `backtrace` feature from `anyhow` and `with-backtrace` from `log-panics`. Customers can't read these backtraces today, and a future in-engine crash reporter will symbolize native stacks itself — making this ~65 KB of symbolication machinery redundant.

No code changes required: no references to `std::backtrace`, `anyhow::Error::backtrace()`, or `catch_unwind` anywhere in the crate.

## Test plan

- [x] `cargo build --release` succeeds
- [x] `cargo test` — 220 passed, 0 failed
- [ ] CI green