### PR TITLE
fix: atomic state writes and surface flush errors in disk_io

### DIFF
--- a/library/src/cache/disk_io.rs
+++ b/library/src/cache/disk_io.rs
@@ -203,8 +203,11 @@ mod test {
             fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
                 Err(std::io::Error::other("simulated flush failure"))
             }
+            // `BufWriter::into_inner` drains its buffer via the inner
+            // writer's `write`, not its `flush`, so this path is not
+            // exercised by the test. Required by the trait.
             fn flush(&mut self) -> std::io::Result<()> {
-                Err(std::io::Error::other("simulated flush failure"))
+                Ok(())
             }
         }
 

--- a/library/src/cache/disk_io.rs
+++ b/library/src/cache/disk_io.rs
@@ -3,8 +3,8 @@ use anyhow::{bail, Context};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fs::File,
-    io::{BufReader, BufWriter},
-    path::Path,
+    io::{BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
 };
 
 pub fn write<S, P>(serializable: &S, path: &P) -> anyhow::Result<()>
@@ -24,10 +24,58 @@ where
     std::fs::create_dir_all(containing_dir)
         .with_file_context(FileOperation::CreateDir, containing_dir)?;
 
-    let file = File::create(path).with_file_context(FileOperation::CreateFile, path_as_ref)?;
-    let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, serializable)
-        .with_context(|| format!("failed to serialize to {:?}", path_as_ref))
+    // Write to a sibling temp file first, then atomically rename into place.
+    // Two problems with writing directly to `path`:
+    //   1. `BufWriter`'s `Drop` impl silently discards flush errors, so a
+    //      transient I/O failure (iOS Data Protection lock, ENOSPC) on the
+    //      final flush leaves a zero-byte file on disk with no error returned.
+    //   2. A crash or power loss between `File::create` (which truncates) and
+    //      the final write would leave an empty/partial file where a valid
+    //      state file used to be.
+    // The sibling-write-then-rename pattern fixes both: the caller sees a
+    // flush error (we unwrap `BufWriter` below), and on-disk `path` is only
+    // replaced by a fully-written sibling via an atomic `rename`.
+    let temp_path = temp_sibling_path(path_as_ref);
+    let file =
+        File::create(&temp_path).with_file_context(FileOperation::CreateFile, &temp_path)?;
+    if let Err(err) = serialize_and_flush(serializable, file)
+        .with_context(|| format!("failed to serialize to {:?}", &temp_path))
+    {
+        // Best-effort cleanup so a failed write doesn't leave orphan temp files.
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    std::fs::rename(&temp_path, path_as_ref)
+        .with_file_context(FileOperation::RenameFile, &temp_path)
+}
+
+/// Serializes `value` as pretty JSON into `writer`, then explicitly unwraps
+/// the internal `BufWriter` so any flush error surfaces to the caller instead
+/// of being silently discarded by `BufWriter`'s `Drop` impl.
+fn serialize_and_flush<S, W>(value: &S, writer: W) -> anyhow::Result<()>
+where
+    S: ?Sized + Serialize,
+    W: Write,
+{
+    let mut buf_writer = BufWriter::new(writer);
+    serde_json::to_writer_pretty(&mut buf_writer, value)?;
+    // `into_inner` calls `flush_buf` internally; any I/O error from writing
+    // out the buffered bytes comes back as `IntoInnerError` rather than being
+    // dropped on the floor.
+    buf_writer
+        .into_inner()
+        .map_err(|e| anyhow::Error::new(e.into_error()))?;
+    Ok(())
+}
+
+/// Returns a sibling path in the same directory with a `.tmp` suffix,
+/// e.g. `/a/b/state.json` -> `/a/b/state.json.tmp`.
+fn temp_sibling_path(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("state");
+    path.with_file_name(format!("{file_name}.tmp"))
 }
 
 pub fn read<D, P>(path: &P) -> anyhow::Result<D>
@@ -93,5 +141,83 @@ mod test {
         assert!(super::read::<TestStruct, _>(&path).is_err());
 
         Ok(())
+    }
+
+    #[test]
+    fn write_does_not_leave_temp_file_on_success() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let path = temp_dir.path().join("state.json");
+        super::write(
+            &TestStruct {
+                a: 1,
+                b: "hi".into(),
+            },
+            &path,
+        )?;
+        assert!(path.exists());
+        assert!(!temp_dir.path().join("state.json.tmp").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn write_preserves_existing_file_on_serialization_failure() -> Result<()> {
+        // Struct whose Serialize impl always fails — simulates an I/O error
+        // encountered during serialization without needing filesystem tricks.
+        struct FailingSerialize;
+        impl serde::Serialize for FailingSerialize {
+            fn serialize<S: serde::Serializer>(&self, _: S) -> std::result::Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom("simulated failure"))
+            }
+        }
+
+        let temp_dir = TempDir::new()?;
+        let path = temp_dir.path().join("state.json");
+        let original = TestStruct {
+            a: 42,
+            b: "original".into(),
+        };
+        super::write(&original, &path)?;
+
+        // Second write fails; the existing file at `path` must still hold the
+        // original contents (the failed write goes to the sibling temp file
+        // and never clobbers `path`).
+        assert!(super::write(&FailingSerialize, &path).is_err());
+        let roundtripped: TestStruct = super::read(&path)?;
+        assert!(roundtripped == original);
+        // Temp file was cleaned up.
+        assert!(!temp_dir.path().join("state.json.tmp").exists());
+        Ok(())
+    }
+
+    // Regression test for the bug where `BufWriter`'s `Drop` impl silently
+    // discards flush errors, producing a spurious Ok() from `write` while
+    // the on-disk file ended up empty or partial. `serialize_and_flush`
+    // must surface such errors.
+    #[test]
+    fn serialize_and_flush_surfaces_error_from_inner_writer() {
+        // A Write impl that fails on every write call. All of serde_json's
+        // output for a small struct fits inside BufWriter's buffer, so the
+        // inner writer's `write` only gets called when the buffer is drained
+        // — either by an explicit flush/into_inner (fix) or by Drop (bug).
+        struct FailingWriter;
+        impl std::io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("simulated flush failure"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Err(std::io::Error::other("simulated flush failure"))
+            }
+        }
+
+        let value = TestStruct {
+            a: 1,
+            b: "hi".into(),
+        };
+        let result = super::serialize_and_flush(&value, FailingWriter);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("simulated flush failure"));
     }
 }

--- a/library/src/cache/disk_io.rs
+++ b/library/src/cache/disk_io.rs
@@ -36,8 +36,7 @@ where
     // flush error (we unwrap `BufWriter` below), and on-disk `path` is only
     // replaced by a fully-written sibling via an atomic `rename`.
     let temp_path = temp_sibling_path(path_as_ref);
-    let file =
-        File::create(&temp_path).with_file_context(FileOperation::CreateFile, &temp_path)?;
+    let file = File::create(&temp_path).with_file_context(FileOperation::CreateFile, &temp_path)?;
     if let Err(err) = serialize_and_flush(serializable, file)
         .with_context(|| format!("failed to serialize to {:?}", &temp_path))
     {
@@ -71,10 +70,7 @@ where
 /// Returns a sibling path in the same directory with a `.tmp` suffix,
 /// e.g. `/a/b/state.json` -> `/a/b/state.json.tmp`.
 fn temp_sibling_path(path: &Path) -> PathBuf {
-    let file_name = path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("state");
+    let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("state");
     path.with_file_name(format!("{file_name}.tmp"))
 }
 
@@ -165,7 +161,10 @@ mod test {
         // encountered during serialization without needing filesystem tricks.
         struct FailingSerialize;
         impl serde::Serialize for FailingSerialize {
-            fn serialize<S: serde::Serializer>(&self, _: S) -> std::result::Result<S::Ok, S::Error> {
+            fn serialize<S: serde::Serializer>(
+                &self,
+                _: S,
+            ) -> std::result::Result<S::Ok, S::Error> {
                 Err(serde::ser::Error::custom("simulated failure"))
             }
         }
@@ -182,8 +181,8 @@ mod test {
         // original contents (the failed write goes to the sibling temp file
         // and never clobbers `path`).
         assert!(super::write(&FailingSerialize, &path).is_err());
-        let roundtripped: TestStruct = super::read(&path)?;
-        assert!(roundtripped == original);
+        let reloaded: TestStruct = super::read(&path)?;
+        assert!(reloaded == original);
         // Temp file was cleaned up.
         assert!(!temp_dir.path().join("state.json.tmp").exists());
         Ok(())

--- a/library/src/cache/disk_io.rs
+++ b/library/src/cache/disk_io.rs
@@ -99,7 +99,7 @@ mod test {
     use serde::{Deserialize, Serialize};
     use tempfile::TempDir;
 
-    use anyhow::{Ok, Result};
+    use anyhow::Result;
 
     #[derive(Serialize, Deserialize, PartialEq, Eq)]
     struct TestStruct {
@@ -140,8 +140,8 @@ mod test {
     }
 
     #[test]
-    fn write_does_not_leave_temp_file_on_success() -> Result<()> {
-        let temp_dir = TempDir::new()?;
+    fn write_does_not_leave_temp_file_on_success() {
+        let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("state.json");
         super::write(
             &TestStruct {
@@ -149,14 +149,14 @@ mod test {
                 b: "hi".into(),
             },
             &path,
-        )?;
+        )
+        .unwrap();
         assert!(path.exists());
         assert!(!temp_dir.path().join("state.json.tmp").exists());
-        Ok(())
     }
 
     #[test]
-    fn write_preserves_existing_file_on_serialization_failure() -> Result<()> {
+    fn write_preserves_existing_file_on_serialization_failure() {
         // Struct whose Serialize impl always fails — simulates an I/O error
         // encountered during serialization without needing filesystem tricks.
         struct FailingSerialize;
@@ -169,23 +169,22 @@ mod test {
             }
         }
 
-        let temp_dir = TempDir::new()?;
+        let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("state.json");
         let original = TestStruct {
             a: 42,
             b: "original".into(),
         };
-        super::write(&original, &path)?;
+        super::write(&original, &path).unwrap();
 
         // Second write fails; the existing file at `path` must still hold the
         // original contents (the failed write goes to the sibling temp file
         // and never clobbers `path`).
         assert!(super::write(&FailingSerialize, &path).is_err());
-        let reloaded: TestStruct = super::read(&path)?;
+        let reloaded: TestStruct = super::read(&path).unwrap();
         assert!(reloaded == original);
         // Temp file was cleaned up.
         assert!(!temp_dir.path().join("state.json.tmp").exists());
-        Ok(())
     }
 
     // Regression test for the bug where `BufWriter`'s `Drop` impl silently


### PR DESCRIPTION
## Summary

- `disk_io::write` now writes to a sibling `<file>.tmp` and `rename`s it into place, and explicitly unwraps the `BufWriter` so flush errors can no longer be silently discarded by `Drop`.
- Extract `serialize_and_flush` helper so the flush-error path is unit-testable.

## Why

`BufWriter`'s `Drop` impl [silently discards flush errors](https://doc.rust-lang.org/std/io/struct.BufWriter.html#impl-Drop-for-BufWriter%3CW%3E). `patches_state.json` and `state.json` comfortably fit in `BufWriter`'s 8 KB buffer, so the only flush that actually hits disk is the implicit one at drop — and on that flush, transient I/O failures (iOS Data Protection lock, `ENOSPC`, etc.) were invisible to the caller.

Cascade:

1. `disk_io::write` returns `Ok` despite a failed flush. Target file is 0 bytes on disk (File::create truncated it).
2. `save_patches_state` → `install_patch` → `update_internal` all return `Ok(UpdateStatus::UpdateInstalled)`.
3. Dart sees `SHOREBIRD_UPDATE_INSTALLED`, no exception thrown from `ShorebirdUpdater.update()`.
4. Next session: `load_patches_state` fails to deserialize the 0-byte file and falls back to `PatchesState::default()` — `next_boot_patch: None`.
5. `checkForUpdate()` → server returns patch N → `should_install_patch(N)` sees `next_boot_patch = None` → `PatchOkToInstall` → `UpdateStatus.outdated`.

This matches a customer report of `await ShorebirdUpdater.update()` succeeding without exception but `checkForUpdate()` continuing to report `updateAvailable` instead of `readyToApply`, at a steady ~0.2%/min. Unrelated to #335; this failure mode isn't caught by the `StateStorageUnavailable` path added in the pending `79f3af8` fix because the error never surfaces from `disk_io::write` in the first place.

## Changes

`library/src/cache/disk_io.rs`:
- `write()` writes to `<path>.tmp`, then `std::fs::rename` into place. `path` is never observed truncated by a concurrent or post-crash read.
- `BufWriter::into_inner()` replaces the implicit-Drop pattern, so flush I/O errors propagate as `anyhow::Error` instead of being swallowed.
- Temp file is cleaned up on serialization/flush failure.

## Test plan

- [x] `cargo test --lib` — all 223 existing tests pass.
- [x] `cargo clippy --lib --tests -- -D warnings` — clean.
- [x] New test `write_does_not_leave_temp_file_on_success` — atomic-rename cleanup.
- [x] New test `write_preserves_existing_file_on_serialization_failure` — failed writes don't clobber `path`.
- [x] New regression test `serialize_and_flush_surfaces_error_from_inner_writer` — uses a `Write` impl that errors on every call to demonstrate the bug the fix addresses. Confirmed to **fail** on the pre-fix code (temporarily reverted `into_inner()` and watched the assertion panic) and pass on the fixed code.