### PR TITLE
chore(shorebird_code_push): v2.0.6

### DIFF
--- a/shorebird_code_push/CHANGELOG.md
+++ b/shorebird_code_push/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 2.0.6
+
+- fix: `checkForUpdate` now reports `restartRequired` when the current patch
+  has been rolled back
+- fix: `update` no longer throws `UpdateException` when no new patch is
+  available to install
+- fix: `update` no longer throws `UpdateException` when another update is
+  already in progress
+- docs: warn that `checkForUpdate` and `update` make network calls and may
+  block app startup if awaited synchronously
+
 # 2.0.5
 
 - docs: fix Discord badge in `README.md`

--- a/shorebird_code_push/pubspec.yaml
+++ b/shorebird_code_push/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_code_push
 description: Check for and download Shorebird code push updates from your app.
-version: 2.0.5
+version: 2.0.6
 homepage: https://shorebird.dev
 repository: https://github.com/shorebirdtech/updater/tree/main/shorebird_code_push
 


### PR DESCRIPTION
## Description

Bump `shorebird_code_push` to `2.0.6` — three bug fixes and a docs improvement since `2.0.5` (2025-09-12).

### Fixes

- **`checkForUpdate` now reports `restartRequired` after a rollback** (#312) — previously returned `upToDate` because the condition short-circuited on a null `next_boot_patch`. After a server-side rollback the Rust updater correctly uninstalls the patch (next → null) but the app is still running the rolled-back code (current non-null). Callers driving a restart banner off `restartRequired` were missing rollback events on every 2.x release.
- **`update` no longer throws on `SHOREBIRD_NO_UPDATE`** (#334) — benign "already up to date" is no longer surfaced as `UpdateException`.
- **`update` no longer throws on `SHOREBIRD_UPDATE_IN_PROGRESS`** (#335) — concurrent updater activity is benign and should not raise.

### Docs

- Added warnings on `checkForUpdate` / `update` about network latency and blocking app startup (#311).

## Risk

Low. No API surface change — same methods, same signatures, same enum values. All behavior changes are strict bug fixes on existing code paths. The rollback fix is pure Dart (no engine coupling); the two "don't throw" fixes are additive (older engines simply never return those status codes).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
- [x] 🗑️ Chore