### PR TITLE
fix: don't clear last_booted_patch when its patch is rolled back (alt to #348)

### DIFF
--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -402,6 +402,7 @@ mod test {
     use crate::{
         network::{
             testing_set_network_hooks, DownloadResult, PatchCheckResponse, UNEXPECTED_DOWNLOAD,
+            UNEXPECTED_REPORT,
         },
         test_utils::write_fake_apk,
     };
@@ -923,6 +924,196 @@ mod test {
 
         // After reporting a launch success, the current patch number should not have changed.
         assert_eq!(shorebird_current_boot_patch_number(), 1);
+    }
+
+    /// Regression test for the patch-to-release rollback bug
+    /// (shorebirdtech/shorebird#3728). Device is running patch 1; the server
+    /// rolls patch 1 back to the base release with no replacement. The
+    /// running session must continue to report `current_boot_patch_number`
+    /// as 1 (the process is still using it) while `next_boot_patch_number`
+    /// becomes 0 (the device will boot the release on next launch). Together
+    /// these signal `restartRequired` to the Dart layer.
+    ///
+    /// Path 1 fix: by leaving `last_booted_patch` alone in the rollback path,
+    /// the existing `currently_booting.or(last_successfully_booted_patch)`
+    /// fallback in `current_boot_patch()` returns the right value without
+    /// any new field.
+    #[serial]
+    #[test]
+    fn rollback_to_release_keeps_current_boot_patch() {
+        testing_reset_config();
+        let tmp_dir = TempDir::new().unwrap();
+
+        let base = "hello world";
+        let apk_path = tmp_dir.path().join("base.apk");
+        write_fake_apk(apk_path.to_str().unwrap(), base.as_bytes());
+        let fake_libapp_path = tmp_dir.path().join("lib/arch/ignored.so");
+        let c_params = parameters(&tmp_dir, fake_libapp_path.to_str().unwrap());
+        let c_yaml = c_string("app_id: foo");
+        assert!(shorebird_init(&c_params, FileCallbacks::new(), c_yaml));
+        free_c_string(c_yaml);
+        free_parameters(c_params);
+
+        testing_set_network_hooks(
+            |_url, _request| {
+                let hash = "bb8f1d041a5cdc259055afe9617136799543e0a7a86f86db82f8c1fadbd8cc45";
+                Ok(PatchCheckResponse {
+                    patch_available: true,
+                    patch: Some(crate::Patch {
+                        number: 1,
+                        hash: hash.to_owned(),
+                        download_url: "ignored".to_owned(),
+                        hash_signature: None,
+                    }),
+                    rolled_back_patch_numbers: None,
+                })
+            },
+            |_url, dest: &Path, _resume_from: u64| {
+                let patch_bytes: Vec<u8> = vec![
+                    40, 181, 47, 253, 0, 128, 177, 0, 0, 223, 177, 0, 0, 0, 16, 0, 0, 6, 0, 0, 0,
+                    0, 0, 0, 5, 116, 101, 115, 116, 115, 0,
+                ];
+                let total_bytes = patch_bytes.len() as u64;
+                std::fs::write(dest, &patch_bytes)?;
+                Ok(DownloadResult {
+                    total_bytes,
+                    content_length: Some(total_bytes),
+                })
+            },
+            |_url, _event| Ok(()),
+        );
+        assert!(shorebird_check_for_downloadable_update(std::ptr::null()));
+        shorebird_update();
+        shorebird_report_launch_start();
+        shorebird_report_launch_success();
+        assert_eq!(shorebird_current_boot_patch_number(), 1);
+        assert_eq!(shorebird_next_boot_patch_number(), 1);
+
+        // Server rolls back patch 1 with no replacement. Phase-1 spawned
+        // threads (PatchDownload, PatchInstallSuccess) hold a clone of the
+        // config from when they were spawned, so they hit the phase-1 hook
+        // above. Phase 2 only does a patch check, so no report is expected.
+        testing_set_network_hooks(
+            |_url, _request| {
+                Ok(PatchCheckResponse {
+                    patch_available: false,
+                    patch: None,
+                    rolled_back_patch_numbers: Some(vec![1]),
+                })
+            },
+            UNEXPECTED_DOWNLOAD,
+            UNEXPECTED_REPORT,
+        );
+        assert!(!shorebird_check_for_downloadable_update(std::ptr::null()));
+
+        // Customer's bug: pre-fix returned 0. Path 1 fix returns 1 because
+        // last_booted_patch is no longer cleared, and the .or() fallback
+        // surfaces it.
+        assert_eq!(shorebird_current_boot_patch_number(), 1);
+        // Next boot has been cleared — device boots release on restart.
+        assert_eq!(shorebird_next_boot_patch_number(), 0);
+    }
+
+    /// Path 1's known limitation: after a patch-to-release rollback and a
+    /// restart, the engine boots the base release. But `last_booted_patch`
+    /// is still `Some(1)` on disk from the previous run, and there's no
+    /// session-scoped signal to override it. The `.or()` fallback in
+    /// `current_boot_patch()` returns `Some(1)`, so `checkForUpdate` would
+    /// keep reporting `restartRequired` even though the app is already on
+    /// release.
+    ///
+    /// This test is `#[ignore]` because Path 1 alone doesn't fix it. The
+    /// alternative approach (PR #348) adds a dedicated session-scoped
+    /// `current_boot_patch` field that's reset on `report_launch_start`,
+    /// which closes this gap. To close it within Path 1, we'd need either
+    /// a session-scoped field anyway, or a clear-on-launch hack — at which
+    /// point we're approximating PR #348.
+    #[serial]
+    #[test]
+    #[ignore]
+    fn rollback_to_release_then_restart_clears_current_boot_patch() {
+        testing_reset_config();
+        let tmp_dir = TempDir::new().unwrap();
+
+        let base = "hello world";
+        let apk_path = tmp_dir.path().join("base.apk");
+        write_fake_apk(apk_path.to_str().unwrap(), base.as_bytes());
+        let fake_libapp_path = tmp_dir.path().join("lib/arch/ignored.so");
+
+        // Phase 1: install patch 1 and report a successful launch.
+        {
+            let c_params = parameters(&tmp_dir, fake_libapp_path.to_str().unwrap());
+            let c_yaml = c_string("app_id: foo");
+            assert!(shorebird_init(&c_params, FileCallbacks::new(), c_yaml));
+            free_c_string(c_yaml);
+            free_parameters(c_params);
+        }
+
+        testing_set_network_hooks(
+            |_url, _request| {
+                let hash = "bb8f1d041a5cdc259055afe9617136799543e0a7a86f86db82f8c1fadbd8cc45";
+                Ok(PatchCheckResponse {
+                    patch_available: true,
+                    patch: Some(crate::Patch {
+                        number: 1,
+                        hash: hash.to_owned(),
+                        download_url: "ignored".to_owned(),
+                        hash_signature: None,
+                    }),
+                    rolled_back_patch_numbers: None,
+                })
+            },
+            |_url, dest: &Path, _resume_from: u64| {
+                let patch_bytes: Vec<u8> = vec![
+                    40, 181, 47, 253, 0, 128, 177, 0, 0, 223, 177, 0, 0, 0, 16, 0, 0, 6, 0, 0, 0,
+                    0, 0, 0, 5, 116, 101, 115, 116, 115, 0,
+                ];
+                let total_bytes = patch_bytes.len() as u64;
+                std::fs::write(dest, &patch_bytes)?;
+                Ok(DownloadResult {
+                    total_bytes,
+                    content_length: Some(total_bytes),
+                })
+            },
+            |_url, _event| Ok(()),
+        );
+        assert!(shorebird_check_for_downloadable_update(std::ptr::null()));
+        shorebird_update();
+        shorebird_report_launch_start();
+        shorebird_report_launch_success();
+        assert_eq!(shorebird_current_boot_patch_number(), 1);
+
+        // Phase 2: server rolls back patch 1.
+        testing_set_network_hooks(
+            |_url, _request| {
+                Ok(PatchCheckResponse {
+                    patch_available: false,
+                    patch: None,
+                    rolled_back_patch_numbers: Some(vec![1]),
+                })
+            },
+            UNEXPECTED_DOWNLOAD,
+            UNEXPECTED_REPORT,
+        );
+        assert!(!shorebird_check_for_downloadable_update(std::ptr::null()));
+
+        // Phase 3: simulate restart — the engine boots release because
+        // next_boot is None. There's no session-scoped reset to clear
+        // last_booted_patch, so .or() still returns the stale 1.
+        testing_reset_config();
+        {
+            let c_params = parameters(&tmp_dir, fake_libapp_path.to_str().unwrap());
+            let c_yaml = c_string("app_id: foo");
+            assert!(shorebird_init(&c_params, FileCallbacks::new(), c_yaml));
+            free_c_string(c_yaml);
+            free_parameters(c_params);
+        }
+        assert_eq!(shorebird_next_boot_patch_number(), 0);
+        shorebird_report_launch_start();
+        // FAILS under Path 1: returns 1 (stale last_booted_patch from the
+        // previous run, surfaced by the .or() fallback). PR #348 fixes
+        // this by resetting current_boot_patch on report_launch_start.
+        assert_eq!(shorebird_current_boot_patch_number(), 0);
     }
 
     #[serial]

--- a/library/src/cache/patch_manager.rs
+++ b/library/src/cache/patch_manager.rs
@@ -312,9 +312,21 @@ impl PatchManager {
             .unwrap_or(false);
 
         if is_bad_patch_last_booted_patch && is_bad_patch_next_boot_patch {
-            // If both patches are bad, delete them both and boot from the base release.
-            shorebird_info!("Clearing last booted patch and next boot patch");
-            self.patches_state.last_booted_patch = None;
+            // The bad patch is both the last successfully-booted patch and the
+            // queued next-boot patch. Clear the next-boot pointer so the
+            // device boots the base release on next launch — but leave
+            // `last_booted_patch` alone. The patch *did* successfully boot,
+            // and the running process is still using it; erasing the
+            // historical record while the field is being read by FFI as
+            // "what's running" was the cause of the patch-to-release
+            // rollback bug (shorebirdtech/shorebird#3728). The "don't fall
+            // back to this patch" intent is already covered: the artifacts
+            // are deleted above by `delete_patch_artifacts(bad_patch_number)`,
+            // and validation in `validate_next_boot_patch` will refuse to
+            // boot a patch whose artifacts are missing.
+            shorebird_info!(
+                "Clearing next boot patch (rollback target was both last booted and next boot)"
+            );
             self.patches_state.next_boot_patch = None;
         } else if is_bad_patch_next_boot_patch {
             shorebird_info!("Clearing next boot patch");
@@ -1445,8 +1457,15 @@ mod record_boot_failure_for_patch_tests {
         Ok(())
     }
 
+    /// Patch 1 successfully booted on a prior run; on this run boot fails.
+    /// `last_successfully_booted_patch` reports the historical fact (patch 1
+    /// did successfully boot once), but `next_boot_patch` is cleared and the
+    /// patch is recorded as known-bad so it won't be retried. The artifact
+    /// is deleted. The "don't fall back to this patch" intent is captured
+    /// by `is_known_bad_patch` and the missing artifact, not by erasing the
+    /// boot history.
     #[test]
-    fn clears_last_booted_patch_if_it_is_the_failed_patch() -> Result<()> {
+    fn preserves_last_booted_patch_on_failure_but_marks_bad() -> Result<()> {
         let temp_dir = TempDir::new()?;
         let mut manager = PatchManager::manager_for_test(&temp_dir);
         manager.add_patch_for_test(&temp_dir, 1)?;
@@ -1463,7 +1482,9 @@ mod record_boot_failure_for_patch_tests {
         // Now pretend it failed to boot
         assert!(manager.record_boot_start_for_patch(1).is_ok());
         assert!(manager.record_boot_failure_for_patch(1).is_ok());
-        assert!(manager.last_successfully_booted_patch().is_none());
+        // Historical fact preserved: patch 1 *did* successfully boot once.
+        assert_eq!(manager.last_successfully_booted_patch().unwrap().number, 1);
+        // Operational state: don't try this patch again.
         assert!(manager.next_boot_patch().is_none());
         assert!(manager.is_known_bad_patch(1));
         assert!(!patch_artifact_path.exists());


### PR DESCRIPTION
## Summary

Companion to #348. Both PRs fix shorebirdtech/shorebird#3728 (customer
report: patch-to-release rollback returns \`upToDate\` instead of
\`restartRequired\`) but take different approaches. This PR exists for
side-by-side comparison; we'll pick one.

## The bug under both lenses

\`last_booted_patch\` is conflated. The field name and
\`record_boot_success\` say it's a *historical* record (\"last patch that
successfully booted, ever\"), but \`try_fall_back_from_patch\` treats it
as an *operational* fallback target and clears it when the patch
becomes invalid as a fallback. Those two roles only diverge under
server rollback. With the field cleared while the process is still
running the patch, the FFI's \`currently_booting.or(last_successfully_booted_patch)\`
fallback returns 0.

## This PR's approach

Fix the conflation directly. In \`try_fall_back_from_patch\`'s \"both
bad\" branch, only clear \`next_boot_patch\`. Leave \`last_booted_patch\`
alone — that history shouldn't change because the server told us not
to use the patch next time. The \"don't fall back to this patch\"
intent is already covered:

- Artifacts are deleted at the top of the function.
- The else-if branch's \`validate_patch_is_bootable\` refuses any
  fallback to a patch with missing artifacts.
- \`is_known_bad_patch\` records boot failures explicitly.

## What works, what doesn't

| Scenario | This PR | #348 |
|---|---|---|
| In-session rollback (customer's bug) | ✅ fixed | ✅ fixed |
| Post-restart: app on release, no false \`restartRequired\` | ❌ broken | ✅ fixed |
| Boot-failure path preserves boot history | ✅ corrected | ➖ unchanged |

The post-restart gap is documented as an \`#[ignore]\`'d test in this
branch (\`rollback_to_release_then_restart_clears_current_boot_patch\`).
After rollback + restart, \`last_booted_patch\` is still \`Some(1)\` on
disk from the previous run. There's no session-scoped signal to say
\"this run is on release.\" The \`.or()\` fallback in
\`current_boot_patch()\` returns the stale 1, and Dart sees a
perpetual \`restartRequired\`.

To close that gap within Path 1, we'd need either:
- A session-scoped field for \"what's running this run\" (which is
  what PR #348 adds), or
- A clear-on-launch hack in \`report_launch_start\` when there's no
  next patch (we discussed this — it's what the user originally
  proposed and then we both agreed was a hack across functions).

So Path 1 alone is genuinely incomplete for full correctness.

## Trade-offs

**This PR:**
- + Smaller diff (~10 lines of production code).
- + Removes the conflation in the data model (the underlying bug).
- + Boot-failure history is correctly preserved (a side improvement).
- − Doesn't fix the post-restart staleness.
- − Still relies on the \`.or()\` fallback, which has its own conceptual
  weirdness (using \"last booted\" as a proxy for \"running\").

**PR #348:**
- + Fixes both in-session and post-restart correctness.
- + Each field has a single, well-scoped role.
- + No \`.or()\` fallback — \`current_boot_patch()\` reads its dedicated
  field directly.
- − Larger diff (new field, trait methods, plumbing).
- − Sidesteps the underlying conflation rather than fixing it. TODOs
  in #348 flag the unresolved \`last_booted_patch\` weirdness.

## What I'd actually do

Combine both. Take the conflation fix from this PR (path 1 — keep
\`last_booted_patch\` historical) and the session-scoped field from
PR #348. Each addresses a different real bug; they're orthogonal.
Keeping just one leaves the other unresolved.

## Test plan

- [x] Path 1 fixes the customer's reported bug at the C API level
- [x] One existing test (\`clears_last_booted_patch_if_it_is_the_failed_patch\`)
      asserts the old behavior; updated to assert new contract under
      a new name
- [x] All other 226 existing tests pass without modification
- [x] Post-restart gap is documented as \`#[ignore]\`'d test (un-ignore
      to reproduce)
- [x] \`cargo fmt --check\` and \`cargo test --lib\` clean
- [ ] Decide between this PR, #348, or both