### PR TITLE
feat(updater): Draft future-release patch prefetch

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -66,6 +66,7 @@ words:
   - msvc
   - nscloud
   - oslog
+  - patchless
   - pubspec
   - repr
   - reqwest

--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -428,6 +428,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -482,6 +483,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -539,6 +541,7 @@ mod test {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: None,
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,
@@ -623,6 +626,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+                    available_release_versions: None,
                 })
             },
             |_url, _dest: &Path, _resume_from: u64| Err(anyhow::anyhow!("Error")),
@@ -673,6 +677,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -739,6 +744,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -768,6 +774,8 @@ mod test {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: Some(vec![1]),
+
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,
@@ -824,6 +832,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -846,6 +855,8 @@ mod test {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: Some(vec![1]),
+
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,
@@ -914,6 +925,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -936,6 +948,8 @@ mod test {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: Some(vec![1]),
+
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,
@@ -959,6 +973,8 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: Some(vec![]),
+
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -1011,6 +1027,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_PATCH_2_PATCH.write_to(dest),
@@ -1035,6 +1052,8 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: Some(vec![2]),
+
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -1123,6 +1142,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,

--- a/library/src/c_api/mod.rs
+++ b/library/src/c_api/mod.rs
@@ -744,7 +744,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -832,7 +832,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -925,7 +925,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_TESTS_PATCH.write_to(dest),
@@ -1027,7 +1027,7 @@ mod test {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| HELLO_PATCH_2_PATCH.write_to(dest),

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -263,10 +263,30 @@ impl PatchCheckRequest {
         client_id: &str,
         current_patch_number: Option<usize>,
     ) -> PatchCheckRequest {
+        Self::new_for_release(
+            config,
+            client_id,
+            &config.release_version,
+            current_patch_number,
+        )
+    }
+
+    /// Builds a patch-check request for an arbitrary `release_version`. Used
+    /// when prefetching patches for sibling releases on the same track that
+    /// the server advertised via `available_release_versions`. For sibling
+    /// fetches `current_patch_number` is always `None` — we're spoofing the
+    /// release_version and the server's own per-release patch number space
+    /// is independent of what we're running.
+    pub fn new_for_release(
+        config: &UpdateConfig,
+        client_id: &str,
+        release_version: &str,
+        current_patch_number: Option<usize>,
+    ) -> PatchCheckRequest {
         PatchCheckRequest {
             app_id: config.app_id.clone(),
             channel: config.channel.clone(),
-            release_version: config.release_version.clone(),
+            release_version: release_version.to_string(),
             platform: current_platform().to_string(),
             arch: current_arch().to_string(),
             client_id: client_id.to_string(),
@@ -295,6 +315,19 @@ pub struct PatchCheckResponse {
     /// uninstalled from the device and not booted from.
     #[serde(default)]
     pub rolled_back_patch_numbers: Option<Vec<usize>>,
+
+    /// Other release_versions on this app's track that have publishable
+    /// patches. The client may issue follow-up `/patches/check` requests
+    /// scoped to each entry to prefetch those patches before the user's
+    /// native binary updates to the corresponding release.
+    ///
+    /// The current release_version is filtered out by the client; the server
+    /// may include or exclude it for convenience.
+    ///
+    /// Older clients that don't recognize this field simply ignore it, so
+    /// it's safe for the server to populate unconditionally.
+    #[serde(default)]
+    pub available_release_versions: Option<Vec<String>>,
 }
 
 /// Reports a patch event (e.g., install success/failure) to the server.

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -492,7 +492,7 @@ fn install_from_patch_check_response(
     }
 
     let patch_number = patch.number;
-    let result = download_and_install_patch(&config, &patch, action);
+    let result = download_and_install_patch(config, &patch, action);
 
     if let Err(ref err) = result {
         // Queue a diagnostic event for the failed update attempt.
@@ -505,7 +505,7 @@ fn install_from_patch_check_response(
         );
         let queue_result = with_mut_state(|state| {
             state.queue_event(PatchEvent::new(
-                &config,
+                config,
                 EventType::PatchUpdateFailure,
                 patch_number,
                 state.client_id(),
@@ -710,14 +710,15 @@ fn mark_patch_bad(patch_number: usize, reason: BadReason) {
 // namespaced by release_version:
 //
 //   <storage_dir>/prefetched_patches/<rv>/patches/<n>/state.json
-//   <download_dir>/prefetched_patches/<rv>/<n>
+//   <storage_dir>/prefetched_patches/<rv>/downloads/<n>
 //
-// This namespace is wholly separate from the per-release `patches/` and
-// `download_dir/<n>` paths the active lifecycle owns — the release-version
-// reset wipes the active store but leaves the prefetched store intact.
-// We construct an independent `PatchLifecycle` against the prefetched
-// roots to reuse `record_download_started`, `record_download_complete`,
-// `read_state`, and `decide_start` for free.
+// The compressed bytes intentionally live under `storage_dir`, not
+// `download_dir`: release-version resets wipe the active download root
+// before promotion runs for the new binary.
+//
+// The prefetched namespace is still modeled as a `PatchLifecycle`, so it
+// uses the same downloaded-state transitions as the active update path
+// without sharing the active release's patch directory.
 //
 // Promotion (in `handle_prior_boot_failure_if_necessary`) finds a
 // prefetched delta matching the now-running release_version, moves the
@@ -736,7 +737,13 @@ fn prefetched_state_root(storage_dir: &Path, release_version: &str) -> PathBuf {
         .join(sanitize_path_component(release_version))
 }
 
-fn prefetched_download_root(download_dir: &Path, release_version: &str) -> PathBuf {
+fn prefetched_download_root(storage_dir: &Path, release_version: &str) -> PathBuf {
+    prefetched_state_root(storage_dir, release_version).join("downloads")
+}
+
+// Older drafts wrote prefetched bytes under the active download root.
+// Keep this helper only so pruning/promotion can clean those directories up.
+fn legacy_prefetched_download_root(download_dir: &Path, release_version: &str) -> PathBuf {
     download_dir
         .join(PREFETCHED_DIR_NAME)
         .join(sanitize_path_component(release_version))
@@ -745,7 +752,7 @@ fn prefetched_download_root(download_dir: &Path, release_version: &str) -> PathB
 fn prefetched_lifecycle(config: &UpdateConfig, release_version: &str) -> PatchLifecycle {
     PatchLifecycle::load_or_default(
         prefetched_state_root(&config.storage_dir, release_version),
-        prefetched_download_root(Path::new(&config.download_dir), release_version),
+        prefetched_download_root(&config.storage_dir, release_version),
     )
 }
 
@@ -891,17 +898,16 @@ fn download_and_store_prefetched_patch(
 
 /// Drops every cached prefetched-release directory whose release_version
 /// isn't in `keep`. Cleans up siblings the server has stopped
-/// advertising, which limits how much disk we hold for indefinitely-stale
-/// future releases.
+/// advertising, which keeps old future-release candidates bounded.
 fn retain_prefetched_release_versions(
     config: &UpdateConfig,
     keep: &[String],
 ) -> anyhow::Result<()> {
     let state_dir = config.storage_dir.join(PREFETCHED_DIR_NAME);
-    let download_dir = Path::new(&config.download_dir).join(PREFETCHED_DIR_NAME);
     if !state_dir.exists() {
         return Ok(());
     }
+    let legacy_download_dir = Path::new(&config.download_dir).join(PREFETCHED_DIR_NAME);
 
     let keep_set: std::collections::HashSet<String> =
         keep.iter().map(|rv| sanitize_path_component(rv)).collect();
@@ -912,7 +918,7 @@ fn retain_prefetched_release_versions(
             let name_str = name.to_string_lossy().to_string();
             if !keep_set.contains(&name_str) {
                 let _ = std::fs::remove_dir_all(entry.path());
-                let _ = std::fs::remove_dir_all(download_dir.join(&name_str));
+                let _ = std::fs::remove_dir_all(legacy_download_dir.join(&name_str));
             }
         }
     }
@@ -949,7 +955,7 @@ fn try_promote_prefetched_patches(
     // regardless of which patches succeeded — successful ones already
     // had their bytes moved out, failed ones stay un-promoted.
     let _ = std::fs::remove_dir_all(&prefetched_root);
-    let _ = std::fs::remove_dir_all(prefetched_download_root(
+    let _ = std::fs::remove_dir_all(legacy_prefetched_download_root(
         Path::new(&config.download_dir),
         &config.release_version,
     ));
@@ -1013,8 +1019,7 @@ fn promote_one_prefetched_patch(
     if let Some(parent) = active_bytes.parent() {
         std::fs::create_dir_all(parent).with_file_context(FileOperation::CreateDir, parent)?;
     }
-    std::fs::rename(&prefetched_bytes, &active_bytes)
-        .with_file_context(FileOperation::RenameFile, &prefetched_bytes)?;
+    move_or_copy_file(&prefetched_bytes, &active_bytes)?;
 
     let active_size = std::fs::metadata(&active_bytes)
         .with_file_context(FileOperation::GetMetadata, &active_bytes)?
@@ -1063,6 +1068,28 @@ fn promote_one_prefetched_patch(
         config.release_version
     );
     Ok(())
+}
+
+/// Move a prefetched delta into the active download namespace.
+///
+/// A rename is expected inside one app sandbox, but falling back to copy
+/// keeps this safe if an embedder points storage and cache at different
+/// filesystems.
+fn move_or_copy_file(from: &Path, to: &Path) -> anyhow::Result<()> {
+    match std::fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            shorebird_warn!(
+                "Failed to move prefetched patch bytes from {:?} to {:?}: {:?}; copying instead",
+                from,
+                to,
+                rename_error
+            );
+            std::fs::copy(from, to).with_file_context(FileOperation::WriteFile, to)?;
+            std::fs::remove_file(from).with_file_context(FileOperation::DeleteFile, from)?;
+            Ok(())
+        }
+    }
 }
 
 fn sanitize_path_component(s: &str) -> String {
@@ -1641,7 +1668,7 @@ pub fn start_update_thread() {
 #[cfg(test)]
 mod tests {
     use serial_test::serial;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::{fs, thread, time::Duration};
     use tempfile::TempDir;
 
@@ -1662,7 +1689,23 @@ mod tests {
         }
     }
 
+    const HELLO_TESTS_PATCH_HASH: &str =
+        "bb8f1d041a5cdc259055afe9617136799543e0a7a86f86db82f8c1fadbd8cc45";
+    // Generated by `string_patch "hello world" "hello tests"`.
+    const HELLO_TESTS_PATCH_BYTES: &[u8] = &[
+        40, 181, 47, 253, 0, 128, 177, 0, 0, 223, 177, 0, 0, 0, 16, 0, 0, 6, 0, 0, 0, 0, 0, 0, 5,
+        116, 101, 115, 116, 115, 0,
+    ];
+
     pub fn init_for_testing(tmp_dir: &TempDir, base_url: Option<&str>) {
+        init_for_testing_with_release(tmp_dir, base_url, "1.0.0+1");
+    }
+
+    pub fn init_for_testing_with_release(
+        tmp_dir: &TempDir,
+        base_url: Option<&str>,
+        release_version: &str,
+    ) {
         testing_reset_config();
         let cache_dir = tmp_dir.path().to_str().unwrap().to_string();
         let mut yaml = "app_id: 1234".to_string();
@@ -1681,7 +1724,7 @@ mod tests {
             crate::AppConfig {
                 app_storage_dir: cache_dir.clone(),
                 code_cache_dir: cache_dir.clone(),
-                release_version: "1.0.0+1".to_string(),
+                release_version: release_version.to_string(),
                 original_libapp_paths: vec![libapp_path],
             },
             Box::new(FakeExternalFileProvider {}),
@@ -1853,6 +1896,126 @@ mod tests {
                 .to_string(),
             "Invalid hash string from server."
         );
+    }
+
+    #[serial]
+    #[test]
+    fn prefetched_patch_survives_release_reset_and_promotes_on_new_release_init(
+    ) -> anyhow::Result<()> {
+        let mut server = mockito::Server::new();
+        let next_release = "1.0.1+2";
+        let sibling_download_url = format!("{}/patches/next/1", server.url());
+        let current_check_response = PatchCheckResponse {
+            patch_available: false,
+            patch: None,
+            rolled_back_patch_numbers: None,
+            available_release_versions: Some(vec![next_release.to_string()]),
+        };
+        let sibling_check_response = PatchCheckResponse {
+            patch_available: true,
+            patch: Some(Patch {
+                number: 1,
+                download_url: sibling_download_url,
+                hash: HELLO_TESTS_PATCH_HASH.to_string(),
+                hash_signature: None,
+            }),
+            rolled_back_patch_numbers: None,
+            available_release_versions: None,
+        };
+        let current_check = server
+            .mock("POST", "/api/v1/patches/check")
+            .match_body(mockito::Matcher::PartialJsonString(
+                r#"{"release_version":"1.0.0+1"}"#.to_string(),
+            ))
+            .with_status(200)
+            .with_body(serde_json::to_string(&current_check_response)?)
+            .create();
+        let sibling_check = server
+            .mock("POST", "/api/v1/patches/check")
+            .match_body(mockito::Matcher::PartialJsonString(format!(
+                r#"{{"release_version":"{}"}}"#,
+                next_release
+            )))
+            .with_status(200)
+            .with_body(serde_json::to_string(&sibling_check_response)?)
+            .create();
+        let sibling_download = server
+            .mock("GET", "/patches/next/1")
+            .with_status(200)
+            .with_body(HELLO_TESTS_PATCH_BYTES)
+            .create();
+
+        let tmp_dir = TempDir::new()?;
+        let base_apk = tmp_dir.path().join("base.apk");
+        write_fake_apk(base_apk.to_str().unwrap(), b"hello world");
+        init_for_testing(&tmp_dir, Some(&server.url()));
+
+        assert_eq!(super::update(None)?, crate::UpdateStatus::NoUpdate);
+        current_check.assert();
+        sibling_check.assert();
+        sibling_download.assert();
+
+        init_for_testing_with_release(&tmp_dir, Some(&server.url()), next_release);
+
+        let next_boot = crate::next_boot_patch()?.expect("prefetched patch should promote");
+        assert_eq!(next_boot.number, 1);
+        assert_eq!(fs::read_to_string(&next_boot.path)?, "hello tests");
+
+        Ok(())
+    }
+
+    #[serial]
+    #[test]
+    fn stale_prefetched_releases_are_pruned() -> anyhow::Result<()> {
+        let tmp_dir = TempDir::new()?;
+        init_for_testing(&tmp_dir, None);
+
+        let (keep_root, stale_root) = with_config(|config| {
+            let keep_root = super::prefetched_state_root(&config.storage_dir, "1.0.1+2");
+            let stale_root = super::prefetched_state_root(&config.storage_dir, "1.0.2+3");
+            fs::create_dir_all(&keep_root)?;
+            fs::create_dir_all(&stale_root)?;
+            super::retain_prefetched_release_versions(config, &["1.0.1+2".to_string()])?;
+            Ok::<(PathBuf, PathBuf), anyhow::Error>((keep_root, stale_root))
+        })?;
+
+        assert!(keep_root.exists());
+        assert!(!stale_root.exists());
+
+        Ok(())
+    }
+
+    #[serial]
+    #[test]
+    fn missing_prefetched_bytes_fall_back_without_promoting() -> anyhow::Result<()> {
+        let tmp_dir = TempDir::new()?;
+        write_fake_apk(
+            tmp_dir.path().join("base.apk").to_str().unwrap(),
+            b"hello world",
+        );
+        init_for_testing(&tmp_dir, None);
+
+        with_config(|config| {
+            let lc = super::prefetched_lifecycle(config, "1.0.1+2");
+            lc.record_download_started(
+                1,
+                "https://example.com/patch",
+                HELLO_TESTS_PATCH_HASH,
+                None,
+            )?;
+            lc.record_download_complete(1, HELLO_TESTS_PATCH_BYTES.len() as u64)?;
+            let bytes_path = lc.download_artifact_path(1);
+            if bytes_path.exists() {
+                fs::remove_file(bytes_path)?;
+            }
+            Ok(())
+        })?;
+
+        init_for_testing_with_release(&tmp_dir, None, "1.0.1+2");
+
+        assert!(crate::next_boot_patch()?.is_none());
+
+        Ok(())
     }
 
     #[serial]

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -9,7 +9,9 @@ use crate::file_errors::{FileOperation, IoResultExt};
 use anyhow::{bail, Context, Result};
 use dyn_clone::DynClone;
 
-use crate::cache::lifecycle::{self, BadReason, DownloadAction, PatchLifecycle, PatchState, SkipReason};
+use crate::cache::lifecycle::{
+    self, BadReason, DownloadAction, PatchLifecycle, PatchState, SkipReason,
+};
 use crate::cache::{PatchInfo, UpdaterState};
 use crate::config::{set_config, with_config, UpdateConfig};
 use crate::events::{EventType, PatchEvent};
@@ -711,7 +713,10 @@ fn has_prefetched_downloaded(
     patch_number: usize,
 ) -> bool {
     let lc = prefetched_lifecycle(config, release_version);
-    matches!(lc.read_state(patch_number), Some(PatchState::Downloaded { .. }))
+    matches!(
+        lc.read_state(patch_number),
+        Some(PatchState::Downloaded { .. })
+    )
 }
 
 /// For each sibling release_version on the same track, downloads the raw
@@ -843,7 +848,10 @@ fn download_and_store_prefetched_patch(
 /// isn't in `keep`. Cleans up siblings the server has stopped
 /// advertising, which limits how much disk we hold for indefinitely-stale
 /// future releases.
-fn retain_prefetched_release_versions(config: &UpdateConfig, keep: &[String]) -> anyhow::Result<()> {
+fn retain_prefetched_release_versions(
+    config: &UpdateConfig,
+    keep: &[String],
+) -> anyhow::Result<()> {
     let state_dir = config.storage_dir.join(PREFETCHED_DIR_NAME);
     let download_dir = Path::new(&config.download_dir).join(PREFETCHED_DIR_NAME);
     if !state_dir.exists() {
@@ -1020,7 +1028,6 @@ fn sanitize_path_component(s: &str) -> String {
         })
         .collect()
 }
-
 
 fn roll_back_patches_if_needed(patch_numbers: Vec<usize>) -> anyhow::Result<()> {
     with_mut_state(|state| {
@@ -2204,7 +2211,7 @@ patch_verification: bogus_mode
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| {
@@ -2472,7 +2479,7 @@ patch_verification: bogus_mode
                         patch_available: false,
                         patch: None,
                         rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                        available_release_versions: None,
                     });
                 }
 
@@ -3282,7 +3289,7 @@ mod download_validation_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, _dest: &Path, _resume_from: u64| {
@@ -3330,7 +3337,7 @@ mod download_validation_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| {
@@ -3379,7 +3386,7 @@ mod download_validation_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| {
@@ -3418,7 +3425,7 @@ mod download_validation_tests {
                     patch_available: true,
                     patch: None, // Server says available but doesn't provide patch.
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             |_url, _dest: &Path, _resume_from: u64| {
@@ -3609,7 +3616,7 @@ mod resume_edge_case_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             download_fn,
@@ -3898,7 +3905,7 @@ mod resume_edge_case_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             crate::network::UNEXPECTED_DOWNLOAD,
@@ -3937,7 +3944,7 @@ mod multi_engine_tests {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: None,
-            available_release_versions: None,
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -3,22 +3,20 @@
 use std::fmt::{Debug, Display, Formatter};
 use std::fs::{self};
 use std::io::{Cursor, Read, Seek};
-use std::path::Path;
-// PathBuf is only used by `libapp_path_from_settings`, which is itself
-// gated to non-android, non-test builds.
-#[cfg(not(any(target_os = "android", test)))]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::file_errors::{FileOperation, IoResultExt};
 use anyhow::{bail, Context, Result};
 use dyn_clone::DynClone;
 
-use crate::cache::lifecycle::{self, BadReason, DownloadAction, SkipReason};
+use crate::cache::lifecycle::{self, BadReason, DownloadAction, PatchLifecycle, PatchState, SkipReason};
 use crate::cache::{PatchInfo, UpdaterState};
 use crate::config::{set_config, with_config, UpdateConfig};
 use crate::events::{EventType, PatchEvent};
 use crate::logging::init_logging;
-use crate::network::{download_to_path, patches_check_url, NetworkHooks, PatchCheckRequest};
+use crate::network::{
+    download_to_path, patches_check_url, NetworkHooks, PatchCheckRequest, PatchCheckResponse,
+};
 use crate::updater_lock::{with_updater_thread_lock, UpdaterLockState};
 use crate::yaml::YamlConfig;
 
@@ -258,6 +256,17 @@ pub fn handle_prior_boot_failure_if_necessary() -> Result<(), InitError> {
             ))?;
         }
 
+        // If a previous run prefetched a patch for the now-running release,
+        // inflate it against this binary and promote it into the active
+        // patch lifecycle. Best-effort; failures don't break init.
+        if let Err(e) = try_promote_prefetched_patches(&mut state, config) {
+            shorebird_warn!(
+                "Failed to promote prefetched patches for {}: {:?}",
+                config.release_version,
+                e
+            );
+        }
+
         Ok(())
     })
     .map_err(|e| {
@@ -426,6 +435,33 @@ fn update_internal(_: &UpdaterLockState, channel: Option<&str>) -> anyhow::Resul
     let response = patch_check_request_fn(&patches_check_url(&config.base_url), request)?;
     shorebird_info!("Patch check response: {:?}", response);
 
+    // Carve off the sibling-release list before consuming the rest of the
+    // response in the main install path. Server-side, this is populated
+    // from the set of release_versions on this app's track that have a
+    // publishable patch; older clients ignore it.
+    let advertised_siblings = response.available_release_versions.clone();
+    let main_status = install_from_patch_check_response(&config, response)?;
+
+    // Best-effort: prefetch patches for sibling releases the server advertised.
+    // Failures here don't affect the main update result.
+    if let Some(siblings) = advertised_siblings {
+        if let Err(e) = prefetch_sibling_release_patches(&config, siblings) {
+            shorebird_warn!("Sibling-release patch prefetch failed: {:?}", e);
+        }
+    }
+
+    Ok(main_status)
+}
+
+/// Acts on a patch-check response for the running release: rolls back any
+/// patches the server marked rolled-back, then downloads, inflates, and
+/// installs the response's patch (if any). Extracted from
+/// `update_internal` so the prefetch tail can run independently of which
+/// of this function's early-returns fired.
+fn install_from_patch_check_response(
+    config: &UpdateConfig,
+    response: PatchCheckResponse,
+) -> anyhow::Result<UpdateStatus> {
     if let Some(rolled_back_patches) = response.rolled_back_patch_numbers {
         roll_back_patches_if_needed(rolled_back_patches)?;
     }
@@ -524,7 +560,7 @@ fn update_internal(_: &UpdaterLockState, channel: Option<&str>) -> anyhow::Resul
         shorebird_info!("Prior download already complete; skipping fetch.");
     }
 
-    install_downloaded_patch(&config, &patch, &download_path)
+    install_downloaded_patch(config, &patch, &download_path)
 }
 
 /// Inflates the compressed bytes at `download_path` into the lifecycle's
@@ -610,6 +646,381 @@ fn mark_patch_bad(patch_number: usize, reason: BadReason) {
         );
     }
 }
+
+// =============================================================================
+// Sibling-release prefetch
+// =============================================================================
+//
+// Closes the patchless-first-launch gap from
+// shorebirdtech/shorebird#3755. When a user's native binary auto-updates
+// between Shorebird patch-checks, the device today must boot the unpatched
+// new release until the next patch-check completes. The prefetch path
+// parks raw deltas for *other* release_versions on the same track so
+// that when the user later updates to one of them, the matching delta
+// is already on disk and gets promoted into the active boot path on init.
+//
+// Layout for prefetched patches mirrors the per-release lifecycle, just
+// namespaced by release_version:
+//
+//   <storage_dir>/prefetched_patches/<rv>/patches/<n>/state.json
+//   <download_dir>/prefetched_patches/<rv>/<n>
+//
+// This namespace is wholly separate from the per-release `patches/` and
+// `download_dir/<n>` paths the active lifecycle owns — the release-version
+// reset wipes the active store but leaves the prefetched store intact.
+// We construct an independent `PatchLifecycle` against the prefetched
+// roots to reuse `record_download_started`, `record_download_complete`,
+// `read_state`, and `decide_start` for free.
+//
+// Promotion (in `handle_prior_boot_failure_if_necessary`) finds a
+// prefetched delta matching the now-running release_version, moves the
+// compressed bytes into the active download root, writes `Downloaded`
+// state into the active patches dir, then runs the existing
+// inflate → check_hash → record_install_complete → promote_to_next_boot
+// pipeline against it. The new binary's `patch_public_key` is the right
+// key for both hash verification and Strict-mode boot signing; no
+// special handling is needed.
+
+const PREFETCHED_DIR_NAME: &str = "prefetched_patches";
+
+fn prefetched_state_root(storage_dir: &Path, release_version: &str) -> PathBuf {
+    storage_dir
+        .join(PREFETCHED_DIR_NAME)
+        .join(sanitize_path_component(release_version))
+}
+
+fn prefetched_download_root(download_dir: &Path, release_version: &str) -> PathBuf {
+    download_dir
+        .join(PREFETCHED_DIR_NAME)
+        .join(sanitize_path_component(release_version))
+}
+
+fn prefetched_lifecycle(config: &UpdateConfig, release_version: &str) -> PatchLifecycle {
+    PatchLifecycle::load_or_default(
+        prefetched_state_root(&config.storage_dir, release_version),
+        prefetched_download_root(Path::new(&config.download_dir), release_version),
+    )
+}
+
+/// True if a `Downloaded` delta with this patch number is already cached
+/// for `release_version`. Used to skip redundant downloads on repeated
+/// prefetch passes.
+fn has_prefetched_downloaded(
+    config: &UpdateConfig,
+    release_version: &str,
+    patch_number: usize,
+) -> bool {
+    let lc = prefetched_lifecycle(config, release_version);
+    matches!(lc.read_state(patch_number), Some(PatchState::Downloaded { .. }))
+}
+
+/// For each sibling release_version on the same track, downloads the raw
+/// delta and parks it under `prefetched_patches/<rv>/`. No inflation,
+/// hash check, or signature check at prefetch time — the running binary
+/// is the wrong inflation base for any release other than its own.
+/// Promotion handles all of that later, after the binary updates.
+fn prefetch_sibling_release_patches(
+    config: &UpdateConfig,
+    advertised_siblings: Vec<String>,
+) -> anyhow::Result<()> {
+    let siblings: Vec<String> = advertised_siblings
+        .into_iter()
+        .filter(|rv| rv.as_str() != config.release_version.as_str())
+        .collect();
+
+    // Drop cached entries the server is no longer advertising.
+    if let Err(e) = retain_prefetched_release_versions(config, &siblings) {
+        shorebird_warn!("Failed to prune stale prefetched patches: {:?}", e);
+    }
+
+    if siblings.is_empty() {
+        return Ok(());
+    }
+
+    let client_id = with_state(|state| Ok(state.client_id()))?;
+    let request_fn = config.network_hooks.patch_check_request_fn;
+    let url = patches_check_url(&config.base_url);
+
+    for release_version in &siblings {
+        // Spoof `release_version`; we have no installed patch on that
+        // release so `current_patch_number` is None.
+        let request = PatchCheckRequest::new_for_release(config, &client_id, release_version, None);
+        let response = match request_fn(&url, request) {
+            Ok(r) => r,
+            Err(e) => {
+                shorebird_warn!(
+                    "Patch check for sibling release {} failed: {:?}",
+                    release_version,
+                    e
+                );
+                continue;
+            }
+        };
+
+        if !response.patch_available {
+            continue;
+        }
+        let patch = match response.patch {
+            Some(p) => p,
+            None => continue,
+        };
+
+        if has_prefetched_downloaded(config, release_version, patch.number) {
+            shorebird_debug!(
+                "Already have prefetched patch {} for release {}, skipping download",
+                patch.number,
+                release_version
+            );
+            continue;
+        }
+
+        if let Err(e) = download_and_store_prefetched_patch(config, release_version, &patch) {
+            shorebird_warn!(
+                "Failed to prefetch patch for sibling release {}: {:?}",
+                release_version,
+                e
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Downloads `patch` into the prefetched namespace for `release_version`
+/// and records a `Downloaded` state for it. Reuses the per-patch
+/// lifecycle's transition machinery so promotion later goes through the
+/// same `Downloaded → Installed` path the active flow uses.
+fn download_and_store_prefetched_patch(
+    config: &UpdateConfig,
+    release_version: &str,
+    patch: &crate::network::Patch,
+) -> anyhow::Result<()> {
+    let lc = prefetched_lifecycle(config, release_version);
+    lc.record_download_started(
+        patch.number,
+        &patch.download_url,
+        &patch.hash,
+        patch.hash_signature.as_deref(),
+    )?;
+
+    let download_path = lc.download_artifact_path(patch.number);
+    if let Some(parent) = download_path.parent() {
+        std::fs::create_dir_all(parent).with_file_context(FileOperation::CreateDir, parent)?;
+    }
+    let dl_result = download_to_path(
+        &config.network_hooks,
+        &patch.download_url,
+        &download_path,
+        0,
+    )?;
+
+    if let Some(expected) = dl_result.content_length {
+        if dl_result.total_bytes != expected {
+            // Bytes don't match the server's Content-Length; drop the
+            // partial. We don't `mark_bad` because that's a
+            // per-release-version concept and this is a different
+            // release_version from the running one.
+            let _ = std::fs::remove_file(&download_path);
+            bail!(
+                "Sibling-release download size mismatch: expected {} bytes, got {}",
+                expected,
+                dl_result.total_bytes
+            );
+        }
+    }
+
+    lc.record_download_complete(patch.number, dl_result.total_bytes)?;
+
+    shorebird_info!(
+        "Prefetched patch {} for sibling release {}",
+        patch.number,
+        release_version
+    );
+    Ok(())
+}
+
+/// Drops every cached prefetched-release directory whose release_version
+/// isn't in `keep`. Cleans up siblings the server has stopped
+/// advertising, which limits how much disk we hold for indefinitely-stale
+/// future releases.
+fn retain_prefetched_release_versions(config: &UpdateConfig, keep: &[String]) -> anyhow::Result<()> {
+    let state_dir = config.storage_dir.join(PREFETCHED_DIR_NAME);
+    let download_dir = Path::new(&config.download_dir).join(PREFETCHED_DIR_NAME);
+    if !state_dir.exists() {
+        return Ok(());
+    }
+
+    let keep_set: std::collections::HashSet<String> =
+        keep.iter().map(|rv| sanitize_path_component(rv)).collect();
+
+    if let Ok(entries) = std::fs::read_dir(&state_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy().to_string();
+            if !keep_set.contains(&name_str) {
+                let _ = std::fs::remove_dir_all(entry.path());
+                let _ = std::fs::remove_dir_all(download_dir.join(&name_str));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// If a previous run prefetched a delta for the now-running release,
+/// move the compressed bytes into the active download root, write
+/// `Downloaded` state under the active patches dir, then run the
+/// existing inflate → hash-check → install pipeline against it. Any
+/// failure removes the prefetched entry so we don't loop. Whatever's
+/// left under `prefetched_patches/<current_rv>/` after promotion is
+/// removed.
+fn try_promote_prefetched_patches(
+    state: &mut UpdaterState,
+    config: &UpdateConfig,
+) -> anyhow::Result<()> {
+    let prefetched_root = prefetched_state_root(&config.storage_dir, &config.release_version);
+    if !prefetched_root.exists() {
+        return Ok(());
+    }
+
+    let patch_numbers = list_prefetched_patch_numbers(&prefetched_root);
+    if !patch_numbers.is_empty() {
+        let lc = prefetched_lifecycle(config, &config.release_version);
+        for n in patch_numbers {
+            if let Err(e) = promote_one_prefetched_patch(state, config, &lc, n) {
+                shorebird_warn!("Failed to promote prefetched patch {}: {:?}", n, e);
+            }
+        }
+    }
+
+    // Clean up the now-current release's prefetched directory tree
+    // regardless of which patches succeeded — successful ones already
+    // had their bytes moved out, failed ones stay un-promoted.
+    let _ = std::fs::remove_dir_all(&prefetched_root);
+    let _ = std::fs::remove_dir_all(prefetched_download_root(
+        Path::new(&config.download_dir),
+        &config.release_version,
+    ));
+
+    Ok(())
+}
+
+fn list_prefetched_patch_numbers(prefetched_state_root: &Path) -> Vec<usize> {
+    let patches_dir = prefetched_state_root.join("patches");
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&patches_dir) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if let Ok(n) = name.parse::<usize>() {
+                    out.push(n);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Single-patch promotion. Reads the prefetched `Downloaded` state,
+/// moves the compressed bytes into the active download root, writes
+/// `Downloaded` into the active patches dir, then runs the same
+/// inflate + hash-check + record_install_complete + promote_to_next_boot
+/// pipeline `install_downloaded_patch` uses for the current release.
+/// Failures mark the patch `Bad` in the active lifecycle so we don't
+/// retry within this release.
+fn promote_one_prefetched_patch(
+    state: &mut UpdaterState,
+    config: &UpdateConfig,
+    prefetched_lc: &PatchLifecycle,
+    n: usize,
+) -> anyhow::Result<()> {
+    let prefetched_state = prefetched_lc
+        .read_state(n)
+        .context("prefetched patch has no state file")?;
+    let (url, hash, signature, _size) = match prefetched_state {
+        PatchState::Downloaded {
+            url,
+            hash,
+            signature,
+            size,
+        } => (url, hash, signature, size),
+        other => bail!("prefetched patch in unexpected state: {:?}", other),
+    };
+
+    if state.is_known_bad_patch(n) {
+        // The active release already tombstoned this patch number; skip
+        // (the prefetched dir gets wiped by the caller anyway).
+        return Ok(());
+    }
+
+    let prefetched_bytes = prefetched_lc.download_artifact_path(n);
+    if !prefetched_bytes.exists() {
+        bail!("prefetched delta missing at {:?}", prefetched_bytes);
+    }
+
+    let active_bytes = lifecycle::download_artifact_path(Path::new(&config.download_dir), n);
+    if let Some(parent) = active_bytes.parent() {
+        std::fs::create_dir_all(parent).with_file_context(FileOperation::CreateDir, parent)?;
+    }
+    std::fs::rename(&prefetched_bytes, &active_bytes)
+        .with_file_context(FileOperation::RenameFile, &prefetched_bytes)?;
+
+    let active_size = std::fs::metadata(&active_bytes)
+        .with_file_context(FileOperation::GetMetadata, &active_bytes)?
+        .len();
+
+    state.lifecycle_mut().write_state(
+        n,
+        &PatchState::Downloaded {
+            url: url.clone(),
+            hash: hash.clone(),
+            signature: signature.clone(),
+            size: active_size,
+        },
+    )?;
+
+    let installed_path = lifecycle::installed_artifact_path(&config.storage_dir, n);
+    if let Some(parent) = installed_path.parent() {
+        std::fs::create_dir_all(parent).with_file_context(FileOperation::CreateDir, parent)?;
+    }
+
+    let patch_base_rs = patch_base(config)?;
+    if let Err(e) = inflate(&active_bytes, patch_base_rs, &installed_path) {
+        state
+            .lifecycle_mut()
+            .mark_bad(n, BadReason::InvalidPatchBytes)?;
+        return Err(e);
+    }
+    if let Err(e) = check_hash(&installed_path, &hash) {
+        state
+            .lifecycle_mut()
+            .mark_bad(n, BadReason::InstallHashMismatch)?;
+        return Err(e);
+    }
+
+    let installed_size = std::fs::metadata(&installed_path)
+        .with_file_context(FileOperation::GetMetadata, &installed_path)?
+        .len();
+    state
+        .lifecycle_mut()
+        .record_install_complete(n, installed_size)?;
+    state.lifecycle_mut().promote_to_next_boot(n)?;
+
+    shorebird_info!(
+        "Promoted prefetched patch {} into active store for release {}",
+        n,
+        config.release_version
+    );
+    Ok(())
+}
+
+fn sanitize_path_component(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | '+' | '-' | '_' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
 
 fn roll_back_patches_if_needed(patch_numbers: Vec<usize>) -> anyhow::Result<()> {
     with_mut_state(|state| {
@@ -1194,6 +1605,8 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: Some(vec![2]),
+
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1268,6 +1681,8 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: Some(vec![2]),
+
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1557,6 +1972,7 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1607,6 +2023,7 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1639,6 +2056,7 @@ patch_verification: bogus_mode
             patch_available: false,
             patch: None,
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1716,6 +2134,7 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1785,6 +2204,7 @@ patch_verification: bogus_mode
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| {
@@ -1832,6 +2252,7 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1894,6 +2315,7 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -1977,6 +2399,7 @@ patch_verification: bogus_mode
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: None,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -2049,6 +2472,7 @@ patch_verification: bogus_mode
                         patch_available: false,
                         patch: None,
                         rolled_back_patch_numbers: None,
+            available_release_versions: None,
                     });
                 }
 
@@ -2127,6 +2551,7 @@ mod rollback_tests {
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: Some(vec![3, 2]),
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -2193,6 +2618,8 @@ mod rollback_tests {
             patch_available: false,
             patch: None,
             rolled_back_patch_numbers: Some(vec![]),
+
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -2232,6 +2659,8 @@ mod rollback_tests {
             patch_available: false,
             patch: None,
             rolled_back_patch_numbers: Some(vec![1]),
+
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -2279,6 +2708,8 @@ mod rollback_tests {
                 hash_signature: None,
             }),
             rolled_back_patch_numbers: Some(vec![2]),
+
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -2362,6 +2793,7 @@ mod check_for_downloadable_update_tests {
                 hash_signature: None,
             }),
             rolled_back_patch_numbers,
+            available_release_versions: None,
         };
         let check_response_body = serde_json::to_string(&check_response).unwrap();
         let _ = server
@@ -2850,6 +3282,7 @@ mod download_validation_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, _dest: &Path, _resume_from: u64| {
@@ -2897,6 +3330,7 @@ mod download_validation_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| {
@@ -2945,6 +3379,7 @@ mod download_validation_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, dest: &Path, _resume_from: u64| {
@@ -2983,6 +3418,7 @@ mod download_validation_tests {
                     patch_available: true,
                     patch: None, // Server says available but doesn't provide patch.
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             |_url, _dest: &Path, _resume_from: u64| {
@@ -3069,6 +3505,8 @@ mod rollback_unit_tests {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: Some(vec![99]),
+
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,
@@ -3112,6 +3550,7 @@ mod rollback_unit_tests {
                     patch: None,
                     // Roll back both patches.
                     rolled_back_patch_numbers: Some(vec![1, 2]),
+                    available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,
@@ -3170,6 +3609,7 @@ mod resume_edge_case_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             download_fn,
@@ -3458,6 +3898,7 @@ mod resume_edge_case_tests {
                         hash_signature: None,
                     }),
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             crate::network::UNEXPECTED_DOWNLOAD,
@@ -3496,6 +3937,7 @@ mod multi_engine_tests {
                     patch_available: false,
                     patch: None,
                     rolled_back_patch_numbers: None,
+            available_release_versions: None,
                 })
             },
             UNEXPECTED_DOWNLOAD,


### PR DESCRIPTION
Part of a proposed solution to close shorebirdtech/shorebird#3755, along with  shorebirdtech/shorebird#3781.

Note: This remains a draft client-side proof of concept for the updater portion. It becomes merge-candidate only after the Shorebird API/server can advertise prefetch candidates, and after the public protocol surface is regenerated from that server/OpenAPI source of truth.

## Summary

When a user's native binary auto-updates between Shorebird patch checks, the device today must boot the unpatched new release until the next patch check completes. This change lets the running binary park raw deltas for server-advertised sibling `release_version`s on the same track, so that when the user later updates to one of them, the matching delta is already on disk and can be promoted into the active boot path during init.

This is not intended to solve fresh installs booting unpatched, or in-session patch activation. It is the narrower existing-user continuity gap across native store updates.

## Approach

Built on top of the per-patch lifecycle state machine introduced in #352. A prefetched patch is stored as a `PatchState::Downloaded` document in a parallel namespace keyed by `release_version`:

```text
<storage_dir>/prefetched_patches/<rv>/patches/<n>/state.json
<storage_dir>/prefetched_patches/<rv>/downloads/<n>
```

The compressed bytes intentionally live under `storage_dir`, not `download_dir`, because release-version resets wipe the active download root before promotion runs for the newly updated binary. This fixes the main correctness issue in the earlier draft.

The prefetched namespace is independent of the per-release `patches/` and `download_dir/<n>` paths the active lifecycle owns. It still uses a `PatchLifecycle`, which lets the prefetch path reuse `record_download_started`, `record_download_complete`, `read_state`, and other downloaded-state transitions without sharing the active release's patch directory.

## Wire shape

- Server/API side: extend `PatchCheckResponse` with optional `available_release_versions: Vec<String>`, or an equivalent server-owned prefetch-candidate field, containing release versions on the requesting app's same app/channel/platform/arch track that are useful and safe to prefetch. Older clients ignore the field.
- Public protocol side: shorebirdtech/shorebird#3781 adds the corresponding Dart protocol surface as `PatchCheckResponse.availableReleaseVersions`. That PR is also draft because this package is generated from the public OpenAPI schema, which does not expose the field yet.
- Client side: after the existing patch-check and install flow runs for the current release, iterate over the advertised siblings, excluding the current `release_version`, issue one extra `/patches/check` per sibling with `release_version` overridden, download the raw delta, and record it as `PatchState::Downloaded` in the prefetched namespace.
- Promotion: `handle_prior_boot_failure_if_necessary` also tries to promote a prefetched delta whose release version matches the now-running binary. The compressed bytes are moved into the active download root, a `Downloaded` state is written into the active `patches/<n>/`, then the existing `inflate -> check_hash -> record_install_complete -> promote_to_next_boot` pipeline runs against it.

No inflation or hash/signature verification happens at prefetch time, because the running binary is the wrong inflation base for any release other than its own. The new binary's `patch_public_key` is the right key for hash verification and Strict-mode boot signing at promotion/boot time.

## Lifecycle and cleanup

- Cached siblings the server stops advertising are pruned via `retain_prefetched_release_versions` on every successful patch check.
- Prefetched bytes from the earlier draft path under the active download root are also cleaned up when encountered.
- Missing or evicted prefetched bytes fail safely and fall back to the normal patch-check flow.
- Prefetch errors are best-effort and never affect the main update result.

## Open items for the Shorebird team

- Private API/server change to populate `available_release_versions`, or an equivalent field, from server-selected same-track release candidates.
- Public OpenAPI/protocol regeneration so shorebirdtech/shorebird#3781 comes from the source of truth instead of a manual generated-file edit.
- Decide whether sibling patch checks should include an explicit prefetch marker to avoid distorting release activity analytics.
- Decide whether candidate selection should respect rollout bucketing up front. This branch still asks the server again per sibling, so per-release rollout decisions can also happen during the sibling check.

## Test plan

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`

Local result: `cargo test --workspace` passes with 250 updater tests plus the patch crate test.
