### PR TITLE
fix(inflate): preserve real upstream cause + add diagnostic byte counters

### DIFF
--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -890,7 +890,7 @@ where
         )
     })?;
 
-    shorebird_info!("Base file size: {} bytes", base_total_size);
+    shorebird_debug!("Base file size: {} bytes", base_total_size);
 
     // Atomic counters shared across the decompression thread and this thread.
     let decompressed_into_pipe = Arc::new(AtomicU64::new(0));
@@ -1013,11 +1013,11 @@ where
     // doesn't disappear entirely.
     match (patch_result, decompress_result) {
         (Ok(_), Ok(_)) => {
-            shorebird_info!(
-                "Patch successfully applied to {:?}. {}",
-                output_path,
-                diag
-            );
+            // Match the previous info-level chattiness on the happy path:
+            // a single short success line. Detailed counters land at debug
+            // level for development / opt-in production diagnostics.
+            shorebird_info!("Patch successfully applied to {:?}", output_path);
+            shorebird_debug!("Inflate diagnostics on success: {}", diag);
             Ok(())
         }
         (Err(patch_err), Ok(_)) => {

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -1013,11 +1013,16 @@ where
     // doesn't disappear entirely.
     match (patch_result, decompress_result) {
         (Ok(_), Ok(_)) => {
-            // Match the previous info-level chattiness on the happy path:
-            // a single short success line. Detailed counters land at debug
-            // level for development / opt-in production diagnostics.
-            shorebird_info!("Patch successfully applied to {:?}", output_path);
-            shorebird_debug!("Inflate diagnostics on success: {}", diag);
+            // One info-level line per inflate, with the diagnostic blob
+            // appended. This is the same line count as before this change;
+            // the blob makes the line longer but enables cross-run forensic
+            // comparison (e.g. "did base_size change between this user's
+            // last working patch and the broken one?").
+            shorebird_info!(
+                "Patch successfully applied to {:?}. {}",
+                output_path,
+                diag
+            );
             Ok(())
         }
         (Err(patch_err), Ok(_)) => {

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -722,46 +722,270 @@ fn validate_compressed_patch(patch_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Read wrapper that counts bytes read into a shared `AtomicU64`.
+struct CountingReader<R> {
+    inner: R,
+    bytes_read: std::sync::Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl<R: Read> Read for CountingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes_read
+            .fetch_add(n as u64, std::sync::atomic::Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+/// Read+Seek wrapper that counts bytes read, seek calls, and tracks the last
+/// seek-target position. Used to wrap the base reader inside `inflate` so we
+/// can report exactly where bipatch's interaction with the base reader was
+/// when an error occurred.
+struct CountingReadSeek<RS> {
+    inner: RS,
+    bytes_read: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    seek_count: std::sync::Arc<std::sync::atomic::AtomicU64>,
+    last_seek_pos: std::sync::Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl<RS: Read> Read for CountingReadSeek<RS> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes_read
+            .fetch_add(n as u64, std::sync::atomic::Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+impl<RS: Seek> Seek for CountingReadSeek<RS> {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        let new_pos = self.inner.seek(pos)?;
+        self.last_seek_pos
+            .store(new_pos, std::sync::atomic::Ordering::Relaxed);
+        self.seek_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(new_pos)
+    }
+}
+
+/// Write wrapper that counts bytes written into a shared `AtomicU64`.
+struct CountingWriter<W> {
+    inner: W,
+    bytes_written: std::sync::Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl<W: std::io::Write> std::io::Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.bytes_written
+            .fetch_add(n as u64, std::sync::atomic::Ordering::Relaxed);
+        Ok(n)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Snapshot of all the byte counters that `inflate` keeps, used to format a
+/// single-line diagnostic string for every error path. Field order in the
+/// formatted output mirrors the data-flow direction: compressed input on disk
+/// → decompression thread → pipe → bipatch consumer → output file. The base
+/// reader counters live to the side because bipatch interleaves reads from
+/// the pipe and the base.
+struct InflateDiagnostics {
+    patch_file_size: u64,
+    base_total_size: u64,
+    decompressed_into_pipe: u64,
+    decompressed_out_of_pipe: u64,
+    base_bytes_read: u64,
+    base_seek_count: u64,
+    base_last_seek_pos: u64,
+    output_bytes_written: u64,
+}
+
+impl Display for InflateDiagnostics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "patch_file={}b base_size={}b \
+             decompressed_into_pipe={}b decompressed_out_of_pipe={}b \
+             base_read={}b base_last_seek_pos={} base_seeks={} \
+             output_written={}b",
+            self.patch_file_size,
+            self.base_total_size,
+            self.decompressed_into_pipe,
+            self.decompressed_out_of_pipe,
+            self.base_bytes_read,
+            self.base_last_seek_pos,
+            self.base_seek_count,
+            self.output_bytes_written,
+        )
+    }
+}
+
 /// Given a path to a patch file, and a base file, apply the patch to the base
 /// and write the result to the output path.
+///
+/// On any error, the returned `anyhow::Result` carries a diagnostic context
+/// line containing byte counters for every stream involved in the inflate
+/// pipeline. This lets in-the-wild failures (where we don't have a debugger)
+/// report exactly where in the pipeline a failure happened — was bipatch
+/// truncated mid-stream, did the base reader return short, did the output
+/// write fail, etc.
+///
+/// Error attribution: when both the patching side and the decompression
+/// thread report errors, the patching side is reported as the primary cause.
+/// The decompression error in that case is almost always a downstream
+/// BrokenPipe-style write failure caused by `fresh_r` being dropped after
+/// the bipatch reader/output writer errored — reporting it as primary (as
+/// older versions of this function did) hides the real root cause behind
+/// the misleading "Decompression of patch failed" message. The decompression
+/// error is still surfaced via `.with_context(...)` so a genuine zstd
+/// corruption error remains visible in the chain.
 fn inflate<RS>(patch_path: &Path, base_r: RS, output_path: &Path) -> anyhow::Result<()>
 where
     RS: Read + Seek,
 {
     use comde::de::Decompressor;
     use comde::zstd::ZstdDecompressor;
-    use std::io::{BufReader, BufWriter};
+    use std::io::{BufReader, BufWriter, SeekFrom};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
 
     // Validate the compressed patch before attempting decompression.
     validate_compressed_patch(patch_path)?;
 
+    // Capture sizes up front for diagnostic context.
+    let patch_file_size = fs::metadata(patch_path).map(|m| m.len()).unwrap_or(0);
+
+    shorebird_info!(
+        "Inflating patch from {:?} ({} bytes)",
+        patch_path,
+        patch_file_size
+    );
+
     // Open all our files first for error clarity.  Otherwise we might see
     // PipeReader/Writer errors instead of file open errors.
-    shorebird_info!("Inflating patch from {:?}", patch_path);
     let compressed_patch_r = BufReader::new(
         fs::File::open(patch_path).with_file_context(FileOperation::ReadFile, patch_path)?,
     );
     let output_file_w =
         fs::File::create(output_path).with_file_context(FileOperation::CreateFile, output_path)?;
 
+    // Probe the base size by seeking to end, then reset. This also gives us
+    // the first chance to discover problems with the base reader (e.g. an iOS
+    // CFileProvider returning a bad handle) before we hand it off to bipatch
+    // where any error would surface obliquely through a downstream BrokenPipe.
+    let mut base_r = base_r;
+    let base_total_size = base_r.seek(SeekFrom::End(0)).with_context(|| {
+        format!(
+            "Probing base reader size failed (seek to end). patch_file={}b",
+            patch_file_size
+        )
+    })?;
+    base_r.seek(SeekFrom::Start(0)).with_context(|| {
+        format!(
+            "Resetting base reader to start failed. patch_file={}b base_size={}b",
+            patch_file_size, base_total_size
+        )
+    })?;
+
+    shorebird_info!("Base file size: {} bytes", base_total_size);
+
+    // Atomic counters shared across the decompression thread and this thread.
+    let decompressed_into_pipe = Arc::new(AtomicU64::new(0));
+    let decompressed_out_of_pipe = Arc::new(AtomicU64::new(0));
+    let base_bytes_read = Arc::new(AtomicU64::new(0));
+    let base_seek_count = Arc::new(AtomicU64::new(0));
+    let base_last_seek_pos = Arc::new(AtomicU64::new(0));
+    let output_bytes_written = Arc::new(AtomicU64::new(0));
+
     // Set up a pipe to connect the writing from the decompression thread
     // to the reading of the decompressed patch data on this thread.
     let (patch_r, patch_w) = pipe::pipe();
 
+    // Wrap each end of the pipe and the base/output with counting wrappers.
+    let patch_w_counted = CountingWriter {
+        inner: patch_w,
+        bytes_written: Arc::clone(&decompressed_into_pipe),
+    };
+    let patch_r_counted = CountingReader {
+        inner: patch_r,
+        bytes_read: Arc::clone(&decompressed_out_of_pipe),
+    };
+    let base_r_counted = CountingReadSeek {
+        inner: base_r,
+        bytes_read: Arc::clone(&base_bytes_read),
+        seek_count: Arc::clone(&base_seek_count),
+        last_seek_pos: Arc::clone(&base_last_seek_pos),
+    };
+
     let decompress = ZstdDecompressor::new();
     // Spawn a thread to run the decompression in parallel to the patching.
-    // decompress.copy will block on the pipe being full (I think) and then
-    // when it returns the thread will exit.
+    // decompress.copy will block when the pipe buffer is full and resume
+    // when the bipatch consumer drains data; when it returns the thread exits.
     let decompress_handle =
-        std::thread::spawn(move || decompress.copy(compressed_patch_r, patch_w));
+        std::thread::spawn(move || decompress.copy(compressed_patch_r, patch_w_counted));
 
-    // Do the patch, using the uncompressed patch data from the pipe.
-    let mut fresh_r =
-        bipatch::Reader::new(patch_r, base_r).context("Failed to initialize patch reader")?;
+    // Closure to assemble the current counter snapshot. Captured by reference
+    // so we can format on demand from any error path.
+    let snapshot = || InflateDiagnostics {
+        patch_file_size,
+        base_total_size,
+        decompressed_into_pipe: decompressed_into_pipe.load(Ordering::Relaxed),
+        decompressed_out_of_pipe: decompressed_out_of_pipe.load(Ordering::Relaxed),
+        base_bytes_read: base_bytes_read.load(Ordering::Relaxed),
+        base_seek_count: base_seek_count.load(Ordering::Relaxed),
+        base_last_seek_pos: base_last_seek_pos.load(Ordering::Relaxed),
+        output_bytes_written: output_bytes_written.load(Ordering::Relaxed),
+    };
 
-    // Write out the resulting patched file to the new location.
-    let mut output_w = BufWriter::new(output_file_w);
-    let patch_result = std::io::copy(&mut fresh_r, &mut output_w)
+    // Helper: join the decompression thread, returning the inner error (if
+    // any). The thread's body is `decompress.copy(...) -> std::io::Result<u64>`.
+    // Used from error paths that have already decided to surface a different
+    // upstream cause but still need to reap the thread.
+    fn drain_decompress(
+        handle: std::thread::JoinHandle<std::io::Result<u64>>,
+    ) -> Option<std::io::Error> {
+        match handle.join() {
+            Ok(Ok(_)) => None,
+            Ok(Err(e)) => Some(e),
+            Err(_) => None,
+        }
+    }
+
+    // bipatch::Reader::new takes ownership of patch_r and base_r. Reading the
+    // bipatch header (4-byte magic + 4-byte version) happens here, plus the
+    // initial seek-to-end on the base reader to learn its length, so this is
+    // the first place a malformed patch or a bad base reader can surface.
+    let mut fresh_r = match bipatch::Reader::new(patch_r_counted, base_r_counted) {
+        Ok(r) => r,
+        Err(e) => {
+            // The pipe's reader side was consumed by the failing Reader::new
+            // call (and dropped), so the decompression thread's next write
+            // gets BrokenPipe and the thread exits quickly. Reap the join
+            // handle so we don't leak it.
+            let dec_err = drain_decompress(decompress_handle);
+            let diag = snapshot();
+            return Err(e).with_context(|| {
+                let mut msg = format!("Failed to initialize bipatch reader. {}", diag);
+                if let Some(d) = dec_err {
+                    msg.push_str(&format!(" Decompression thread also errored: {:#}", d));
+                }
+                msg
+            });
+        }
+    };
+
+    // Write out the resulting patched file to the new location, counting
+    // bytes via the wrapper. BufWriter is on the inside so the byte count
+    // reflects bytes that left bipatch, not bytes that hit disk; that's the
+    // signal we actually want (where in the bipatch state machine were we).
+    let mut output_w_counted = CountingWriter {
+        inner: BufWriter::new(output_file_w),
+        bytes_written: Arc::clone(&output_bytes_written),
+    };
+    let patch_result = std::io::copy(&mut fresh_r, &mut output_w_counted)
         .with_file_context(FileOperation::WriteFile, output_path);
 
     // IMPORTANT: Drop the reader side of the pipe before joining the
@@ -776,20 +1000,65 @@ where
     // Always join the decompression thread to get its result.
     let decompress_result = decompress_handle
         .join()
-        .map_err(|_| anyhow::anyhow!("Decompression thread panicked"))?;
+        .map_err(|_| anyhow::anyhow!("Decompression thread panicked. {}", snapshot()))?;
 
-    // If decompression failed, report that as the primary error since it is
-    // the root cause (the patching thread fails as a side-effect when the
-    // pipe writer is dropped).
-    if let Err(decompress_err) = decompress_result {
-        return Err(decompress_err).context("Decompression of patch failed");
+    let diag = snapshot();
+
+    // Error attribution: when both errored, prefer patch_result. The
+    // decompression side's error is overwhelmingly likely to be a downstream
+    // BrokenPipe caused by `fresh_r` being dropped after bipatch already
+    // failed; reporting it as the primary cause hides the real failure
+    // behind a misleading "Decompression of patch failed" message. A genuine
+    // zstd corruption error is still surfaced via `with_context` so it
+    // doesn't disappear entirely.
+    match (patch_result, decompress_result) {
+        (Ok(_), Ok(_)) => {
+            shorebird_info!(
+                "Patch successfully applied to {:?}. {}",
+                output_path,
+                diag
+            );
+            Ok(())
+        }
+        (Err(patch_err), Ok(_)) => {
+            shorebird_error!("Patch application failed; decompression OK. {}", diag);
+            Err(patch_err).with_context(|| format!("Patch application failed. {}", diag))
+        }
+        (Ok(_), Err(decompress_err)) => {
+            // Patch succeeded but decompression reported an error. This can
+            // happen if there are trailing bytes after the data bipatch
+            // consumed, or if the decompressor sees an error closing its
+            // stream after the consumer already finished. Treat as success
+            // with a warning — the output file is already written and will
+            // be hash-checked by the caller.
+            shorebird_info!(
+                "Patch applied OK; decompression thread reported a trailing error \
+                 (likely benign, output already produced): {:#}. {}",
+                decompress_err,
+                diag
+            );
+            Ok(())
+        }
+        (Err(patch_err), Err(decompress_err)) => {
+            // Both errored — the common in-the-wild failure shape. Report
+            // patch_err as the primary cause (the upstream one) and fold
+            // the decompression error into the context chain so a genuine
+            // zstd corruption error remains visible.
+            shorebird_error!(
+                "Patch application failed; decompression thread also errored downstream: {:#}. {}",
+                decompress_err,
+                diag
+            );
+            Err(patch_err).with_context(|| {
+                format!(
+                    "Patch application failed (decompression thread also errored \
+                     downstream, almost always BrokenPipe caused by the upstream \
+                     patch-side failure: {:#}). {}",
+                    decompress_err, diag
+                )
+            })
+        }
     }
-
-    // If decompression succeeded but patching failed, report the patch error.
-    patch_result?;
-
-    shorebird_info!("Patch successfully applied to {:?}", output_path);
-    Ok(())
 }
 
 /// Performs integrity checks on the next boot patch. If the patch fails these checks, the patch
@@ -1502,11 +1771,13 @@ patch_verification: bogus_mode
     }
 
     #[test]
-    fn inflate_fails_with_corrupt_zstd_data() {
+    fn inflate_fails_with_corrupt_zstd_data_reports_bipatch_init_failure() {
         let tmp_dir = TempDir::new().unwrap();
         let patch_path = tmp_dir.path().join("corrupt.patch");
         // Valid zstd magic but garbage content — passes validation but
-        // fails during decompression or patch reading.
+        // fails during decompression. The decompression thread errors
+        // immediately; the pipe closes; bipatch::Reader::new sees an
+        // empty/short stream and fails to read its header.
         let mut data = vec![0x28, 0xB5, 0x2F, 0xFD];
         data.extend_from_slice(b"this is not valid zstd compressed data");
         fs::write(&patch_path, &data).unwrap();
@@ -1516,18 +1787,24 @@ patch_verification: bogus_mode
 
         let err = super::inflate(&patch_path, base, &output_path).unwrap_err();
         let err_chain = format!("{:#}", err);
-        // The error should come from either decompression or patch init —
-        // not the old cryptic "pipe reader has been dropped" message.
+        // With the improved diagnostics, bipatch initialization is what
+        // ultimately fails to read the header. The decompression error
+        // is folded into the context line so it stays visible.
         assert!(
-            err_chain.contains("Decompression of patch failed")
-                || err_chain.contains("Failed to initialize patch reader"),
-            "Expected decompression or patch init error, got: {}",
+            err_chain.contains("Failed to initialize bipatch reader"),
+            "Expected bipatch init failure as primary, got: {}",
+            err_chain
+        );
+        // Diagnostic byte-counter line must be present for postmortem.
+        assert!(
+            err_chain.contains("patch_file=") && err_chain.contains("base_size="),
+            "Expected diagnostic byte counters in error, got: {}",
             err_chain
         );
     }
 
     #[test]
-    fn inflate_reports_decompression_error_as_primary() {
+    fn inflate_when_both_streams_error_reports_patch_side_primary() {
         use comde::com::Compressor;
         use comde::zstd::ZstdCompressor;
 
@@ -1535,13 +1812,13 @@ patch_verification: bogus_mode
 
         // Build a fake uncompressed patch that starts with a valid bipatch
         // header (magic 0xB1DF, version 0x1000 as little-endian u32s) so
-        // that bipatch::Reader::new succeeds.
+        // that bipatch::Reader::new succeeds, then truncates partway through
+        // the data section so std::io::copy errors mid-stream.
         let mut uncompressed = Vec::new();
         uncompressed.extend_from_slice(&0xB1DFu32.to_le_bytes()); // bipatch magic
         uncompressed.extend_from_slice(&0x1000u32.to_le_bytes()); // bipatch version
-        uncompressed.extend_from_slice(&vec![0u8; 1024]); // padding
+        uncompressed.extend_from_slice(&vec![0u8; 1024]); // padding the header expects
 
-        // Compress the valid data into one complete zstd frame.
         let mut compressed = std::io::Cursor::new(Vec::new());
         let compressor = ZstdCompressor::new();
         compressor
@@ -1549,9 +1826,10 @@ patch_verification: bogus_mode
             .unwrap();
         let mut compressed = compressed.into_inner();
 
-        // Append a second, corrupted zstd frame. The decompressor will
-        // successfully decompress the first frame (delivering the bipatch
-        // header so Reader::new succeeds), then fail on this corrupt frame.
+        // Append a corrupt second zstd frame. The decompressor finishes the
+        // first frame (delivering the bipatch header), then errors on the
+        // garbage frame. Bipatch in turn errors when its source pipe goes
+        // away with less data than its state machine wants.
         compressed.extend_from_slice(&[0x28, 0xB5, 0x2F, 0xFD]); // zstd magic
         compressed.extend_from_slice(&[0xFF; 64]); // garbage
 
@@ -1563,11 +1841,66 @@ patch_verification: bogus_mode
 
         let err = super::inflate(&patch_path, base, &output_path).unwrap_err();
         let err_chain = format!("{:#}", err);
+
+        // Patch-side error is now reported as the primary cause; the
+        // decompression error is preserved in the context chain so a
+        // genuine zstd corruption stays visible to the next debugger.
         assert!(
-            err_chain.contains("Decompression of patch failed"),
-            "Expected decompression error as primary cause, got: {}",
+            err_chain.contains("Patch application failed"),
+            "Expected patch-side error as primary cause, got: {}",
             err_chain
         );
+        assert!(
+            err_chain.contains("decompression"),
+            "Expected decompression error to be folded into the chain, got: {}",
+            err_chain
+        );
+        // Diagnostic counters appear on every error path.
+        assert!(
+            err_chain.contains("patch_file=")
+                && err_chain.contains("decompressed_into_pipe=")
+                && err_chain.contains("output_written="),
+            "Expected diagnostic byte counters, got: {}",
+            err_chain
+        );
+    }
+
+    #[test]
+    fn inflate_diagnostics_include_all_counters() {
+        // Verifies the InflateDiagnostics format contract: the diagnostic
+        // line must include every counter we depend on for postmortem,
+        // even when both streams fail very early. If a refactor accidentally
+        // drops one of these fields, in-the-wild bug reports lose visibility
+        // into where the failure happened.
+        let tmp_dir = TempDir::new().unwrap();
+        let patch_path = tmp_dir.path().join("corrupt.patch");
+        let mut data = vec![0x28, 0xB5, 0x2F, 0xFD];
+        data.extend_from_slice(b"junk");
+        fs::write(&patch_path, &data).unwrap();
+
+        let output_path = tmp_dir.path().join("output");
+        let base = std::io::Cursor::new(b"base bytes for the counter test".to_vec());
+
+        let err = super::inflate(&patch_path, base, &output_path).unwrap_err();
+        let err_chain = format!("{:#}", err);
+
+        for needle in [
+            "patch_file=",
+            "base_size=",
+            "decompressed_into_pipe=",
+            "decompressed_out_of_pipe=",
+            "base_read=",
+            "base_last_seek_pos=",
+            "base_seeks=",
+            "output_written=",
+        ] {
+            assert!(
+                err_chain.contains(needle),
+                "Expected '{}' in diagnostic chain, got: {}",
+                needle,
+                err_chain
+            );
+        }
     }
 
     #[test]

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -1018,11 +1018,7 @@ where
             // the blob makes the line longer but enables cross-run forensic
             // comparison (e.g. "did base_size change between this user's
             // last working patch and the broken one?").
-            shorebird_info!(
-                "Patch successfully applied to {:?}. {}",
-                output_path,
-                diag
-            );
+            shorebird_info!("Patch successfully applied to {:?}. {}", output_path, diag);
             Ok(())
         }
         (Err(patch_err), Ok(_)) => {


### PR DESCRIPTION
## Summary

Two fixes that together make `inflate()` failures actionable in the wild:

**1. Error attribution.** Today, `inflate()` always reports `Decompression of patch failed` when the decompression thread's `join` returns `Err`. That's misleading when the real failure was on the patching side — bipatch errors → `fresh_r` gets dropped → decompression thread's next write gets `BrokenPipe` → join returns `Err` → we report decompression as the primary cause. The actual root cause (the patch-side error) gets shadowed and disappears.

This PR flips the priority: when both error, `patch_result` is reported as primary and `decompress_err` is folded into the context chain (so a genuine zstd corruption error doesn't disappear either). The `(Ok, Err)` case — decompression reports a trailing error after bipatch already finished — is now treated as success with an info log; the output was produced and will be hash-checked downstream anyway.

**2. Diagnostic counters.** Every error path now carries a one-line snapshot of every stream in the pipeline:

```
patch_file=66515b base_size=2838304b
decompressed_into_pipe=2853167b decompressed_out_of_pipe=2853167b
base_read=2785583b base_last_seek_pos=25040 base_seeks=307
output_written=2851760b
```

Field meanings:

| Field | What it means |
|---|---|
| `patch_file` | on-disk compressed patch size |
| `base_size` | base reader length (probed via `seek(End(0))` at start) |
| `decompressed_into_pipe` | bytes the zstd thread wrote to the pipe |
| `decompressed_out_of_pipe` | bytes bipatch consumed from the pipe |
| `base_read` | bytes bipatch read from the base reader |
| `base_last_seek_pos` | where the base reader last seeked to |
| `base_seeks` | how many times bipatch seeked the base |
| `output_written` | bytes copied to the output file |

Reading the failing counter directly tells you where in the pipeline things went wrong. For example, a field crash where `base_read=0` immediately implicates the base reader; `decompressed_into_pipe=8 output_written=0` implicates bipatch parsing right after the 8-byte header; a `base_size` that disagrees with the size the host extracted while building the patch implicates install-time munging.

Counters are tracked via `Arc<AtomicU64>` shared with the decompression thread, wrapped around each stream end with three small `CountingReader` / `CountingReadSeek` / `CountingWriter` adapter structs. Format contract is pinned by `inflate_diagnostics_include_all_counters` so future refactors can't drop a field silently.

A secondary fix: the bipatch-init failure path used to early-`?` and leak the decompression thread detached. It now drains the thread and folds any concurrent decompression error into the same error chain.

## Motivation

Investigating a long-standing iOS-standalone patch failure that's hard to reproduce in the wild. On-device log lines were just `Update failed: Decompression of patch failed` — which (as it turns out) was downstream noise. With these counters the next investigator can read the failing pipeline state directly from the device log instead of having to instrument and ship a debug build.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test inflate` — 5/5 pass:
  - `inflate_fails_with_corrupt_zstd_data_reports_bipatch_init_failure` (replaces the old "decompression or patch init" test)
  - `inflate_when_both_streams_error_reports_patch_side_primary` (replaces `inflate_reports_decompression_error_as_primary` — asserts new attribution)
  - `inflate_diagnostics_include_all_counters` (new — pins format contract)
  - `inflate_rejects_invalid_magic`, validation tests
- [x] `cargo test` — 247/247 pass
- [x] Verified diagnostic line shape against a real downloaded iOS patch + local App.framework/App base

## Out of scope

This PR only fixes the error reporting in `inflate`. The actual iOS-standalone patch failure is a separate investigation — these diagnostics are the prerequisite to making that investigation tractable.