### PR TITLE
fix: populate current_patch_number from running_patch, not the boot breadcrumb

### DIFF
--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -282,7 +282,7 @@ pub fn check_for_downloadable_update(channel: Option<&str>) -> anyhow::Result<bo
     let (client_id, current_patch_number) = with_state(|state| {
         Ok((
             state.client_id().to_string(),
-            state.currently_booting_patch().map(|p| p.number),
+            state.running_patch().map(|p| p.number),
         ))
     })?;
 
@@ -417,7 +417,7 @@ fn update_internal(_: &UpdaterLockState, channel: Option<&str>) -> anyhow::Resul
         Ok(PatchCheckRequest::new(
             &config,
             &state.client_id(),
-            state.currently_booting_patch().map(|p| p.number),
+            state.running_patch().map(|p| p.number),
         ))
     })?;
 

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -4080,17 +4080,10 @@ mod multi_engine_tests {
     }
 }
 
-/// Regression tests for the `current_patch_number` field on the patch-check
-/// request.
-///
-/// The field must carry the patch the process is *running* (`running_patch`),
-/// not the transient boot breadcrumb (`currently_booting_patch`). The
-/// breadcrumb is cleared by `report_launch_success` before any
-/// Dart-initiated patch check can fire, so reading it omitted the field from
-/// nearly every request in the fleet. These tests reproduce that steady
-/// state (booted patch, breadcrumb cleared) and assert the request still
-/// carries the running patch number — both at the `check_for_downloadable_update`
-/// and `update` construction sites.
+/// Regression tests asserting the patch-check request's `current_patch_number`
+/// carries the running patch, not the boot breadcrumb (`currently_booting_patch`)
+/// which `report_launch_success` clears before any patch check fires. Covers
+/// both construction sites: `check_for_downloadable_update` and `update`.
 #[cfg(test)]
 mod patch_check_current_patch_number_tests {
     use anyhow::Result;
@@ -4100,7 +4093,9 @@ mod patch_check_current_patch_number_tests {
 
     use crate::{
         check_for_downloadable_update,
-        network::{testing_set_network_hooks, DownloadResult, PatchCheckResponse},
+        network::{
+            testing_set_network_hooks, PatchCheckResponse, UNEXPECTED_DOWNLOAD, UNEXPECTED_REPORT,
+        },
         report_launch_start, report_launch_success,
         test_utils::install_fake_patch,
         update,
@@ -4129,15 +4124,10 @@ mod patch_check_current_patch_number_tests {
         report_launch_start()?;
         report_launch_success()?;
         with_state(|state| {
-            assert!(
-                state.currently_booting_patch().is_none(),
-                "record_boot_success should have cleared the boot breadcrumb"
-            );
-            assert_eq!(
-                state.running_patch().map(|p| p.number),
-                Some(1),
-                "process should still be running patch 1"
-            );
+            // Steady state: the boot breadcrumb is cleared, yet patch 1 is
+            // still the running patch.
+            assert!(state.currently_booting_patch().is_none());
+            assert_eq!(state.running_patch().map(|p| p.number), Some(1));
             Ok(())
         })
     }
@@ -4162,13 +4152,9 @@ mod patch_check_current_patch_number_tests {
                     rolled_back_patch_numbers: None,
                 })
             },
-            |_url, _dest, _resume_from| {
-                Ok(DownloadResult {
-                    total_bytes: 0,
-                    content_length: None,
-                })
-            },
-            |_url, _event| Ok(()),
+            // No update is offered, so neither hook should ever fire.
+            UNEXPECTED_DOWNLOAD,
+            UNEXPECTED_REPORT,
         );
     }
 
@@ -4181,12 +4167,8 @@ mod patch_check_current_patch_number_tests {
 
         check_for_downloadable_update(None)?;
 
-        assert_eq!(
-            CAPTURED.load(Ordering::SeqCst),
-            1,
-            "check request must send running patch 1 as current_patch_number \
-             (-1 = field omitted, i64::MIN = hook never ran)"
-        );
+        // 1 = running patch sent; -1 = field omitted (the bug); i64::MIN = hook never ran.
+        assert_eq!(CAPTURED.load(Ordering::SeqCst), 1);
         Ok(())
     }
 
@@ -4199,12 +4181,8 @@ mod patch_check_current_patch_number_tests {
 
         update(None)?;
 
-        assert_eq!(
-            CAPTURED.load(Ordering::SeqCst),
-            1,
-            "update request must send running patch 1 as current_patch_number \
-             (-1 = field omitted, i64::MIN = hook never ran)"
-        );
+        // 1 = running patch sent; -1 = field omitted (the bug); i64::MIN = hook never ran.
+        assert_eq!(CAPTURED.load(Ordering::SeqCst), 1);
         Ok(())
     }
 }

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -4079,3 +4079,132 @@ mod multi_engine_tests {
         Ok(())
     }
 }
+
+/// Regression tests for the `current_patch_number` field on the patch-check
+/// request.
+///
+/// The field must carry the patch the process is *running* (`running_patch`),
+/// not the transient boot breadcrumb (`currently_booting_patch`). The
+/// breadcrumb is cleared by `report_launch_success` before any
+/// Dart-initiated patch check can fire, so reading it omitted the field from
+/// nearly every request in the fleet. These tests reproduce that steady
+/// state (booted patch, breadcrumb cleared) and assert the request still
+/// carries the running patch number — both at the `check_for_downloadable_update`
+/// and `update` construction sites.
+#[cfg(test)]
+mod patch_check_current_patch_number_tests {
+    use anyhow::Result;
+    use serial_test::serial;
+    use std::sync::atomic::{AtomicI64, Ordering};
+    use tempfile::TempDir;
+
+    use crate::{
+        check_for_downloadable_update,
+        network::{testing_set_network_hooks, DownloadResult, PatchCheckResponse},
+        report_launch_start, report_launch_success,
+        test_utils::install_fake_patch,
+        update,
+        updater::tests::init_for_testing,
+        with_state,
+    };
+
+    /// `current_patch_number` was `None` on the wire (the bug we're guarding).
+    const FIELD_OMITTED: i64 = -1;
+    /// The patch-check hook never ran.
+    const HOOK_NOT_CALLED: i64 = i64::MIN;
+
+    /// Last `current_patch_number` seen by the patch-check hook. Shared by
+    /// both tests; safe because they are `#[serial]` (only one runs at a
+    /// time) and `arrange_capturing_hooks` resets it before each check.
+    static CAPTURED: AtomicI64 = AtomicI64::new(HOOK_NOT_CALLED);
+
+    /// Installs patch 1 and completes a full boot, then asserts the steady
+    /// state in which patch checks actually run: the boot breadcrumb is
+    /// cleared, but the process is still running patch 1. Reading
+    /// `currently_booting_patch` here yields `None` — that is precisely the
+    /// regression this guards against.
+    fn boot_patch_one(tmp_dir: &TempDir) -> Result<()> {
+        init_for_testing(tmp_dir, None);
+        install_fake_patch(1)?;
+        report_launch_start()?;
+        report_launch_success()?;
+        with_state(|state| {
+            assert!(
+                state.currently_booting_patch().is_none(),
+                "record_boot_success should have cleared the boot breadcrumb"
+            );
+            assert_eq!(
+                state.running_patch().map(|p| p.number),
+                Some(1),
+                "process should still be running patch 1"
+            );
+            Ok(())
+        })
+    }
+
+    /// Installs network hooks whose patch-check leg records the request's
+    /// `current_patch_number` into `CAPTURED` (`None` -> `FIELD_OMITTED`) and
+    /// reports no available update.
+    fn arrange_capturing_hooks() {
+        CAPTURED.store(HOOK_NOT_CALLED, Ordering::SeqCst);
+        testing_set_network_hooks(
+            |_url, request| {
+                CAPTURED.store(
+                    request
+                        .current_patch_number
+                        .map(|n| n as i64)
+                        .unwrap_or(FIELD_OMITTED),
+                    Ordering::SeqCst,
+                );
+                Ok(PatchCheckResponse {
+                    patch_available: false,
+                    patch: None,
+                    rolled_back_patch_numbers: None,
+                })
+            },
+            |_url, _dest, _resume_from| {
+                Ok(DownloadResult {
+                    total_bytes: 0,
+                    content_length: None,
+                })
+            },
+            |_url, _event| Ok(()),
+        );
+    }
+
+    #[serial]
+    #[test]
+    fn check_for_downloadable_update_sends_running_patch() -> Result<()> {
+        let tmp_dir = TempDir::new().unwrap();
+        boot_patch_one(&tmp_dir)?;
+        arrange_capturing_hooks();
+
+        check_for_downloadable_update(None)?;
+
+        assert_eq!(
+            CAPTURED.load(Ordering::SeqCst),
+            1,
+            "check request must send running patch 1 as current_patch_number \
+             (-1 = field omitted, i64::MIN = hook never ran)"
+        );
+        Ok(())
+    }
+
+    #[serial]
+    #[test]
+    fn update_sends_running_patch() -> Result<()> {
+        let tmp_dir = TempDir::new().unwrap();
+        boot_patch_one(&tmp_dir)?;
+        arrange_capturing_hooks();
+
+        update(None)?;
+
+        assert_eq!(
+            CAPTURED.load(Ordering::SeqCst),
+            1,
+            "update request must send running patch 1 as current_patch_number \
+             (-1 = field omitted, i64::MIN = hook never ran)"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

`current_patch_number` (added in #343) is read from `currently_booting_patch()` at both patch-check sites (`updater.rs:285`, `:420`). That's a transient boot breadcrumb — `record_boot_success()` clears it before any Dart-initiated patch check fires, so the field is `None` and `skip_serializing_if` drops it from the wire. Result: it reaches the server on a negligible fraction of requests fleet-wide.

Fix: read from `running_patch()` — set at `report_launch_start`, held all session, survives rollback. Same value the FFI symbol `shorebird_current_boot_patch_number` already uses.

```diff
-            state.currently_booting_patch().map(|p| p.number),
+            state.running_patch().map(|p| p.number),
```
(both sites)

## Notes
- `cargo check` passes; no boot-state-machine change.
- Follow-up: raise the console's `3.41.9` floor once this lands in a Flutter release.
