### PR TITLE
feat(updater): classify update failures into stable categories

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -39,6 +39,7 @@ words:
   - dllexport
   - dlopen
   - dorny
+  - downcastable
   - downloadables
   - EACCES
   - EDQUOT
@@ -71,6 +72,7 @@ words:
   - pubspec
   - repr
   - reqwest
+  - retryability
   - rlib
   - roundtrips
   - rsplit

--- a/library/src/events.rs
+++ b/library/src/events.rs
@@ -80,6 +80,13 @@ pub struct PatchEvent {
     /// An optional message to be sent with the event.
     /// Care should be taken that this field *never* contain PII or sensitive information.
     pub message: Option<String>,
+
+    /// For failure events, a stable, low-cardinality classification of the
+    /// failure (the `FailureCategory` code, e.g. "network", "corrupt_patch").
+    /// Sent as structured data so the server does not have to parse it back out
+    /// of `message`. Optional and ignored by servers that don't yet read it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_category: Option<String>,
 }
 
 impl PatchEvent {
@@ -101,6 +108,7 @@ impl PatchEvent {
             release_version: config.release_version.clone(),
             timestamp: time::unix_timestamp(),
             message: message.map(|s| s.to_string()),
+            failure_category: None,
         }
     }
 }

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -154,19 +154,21 @@ pub(crate) enum NetworkError {
     Server { status: u16 },
     /// The request never reached the server: offline, DNS failure, connection
     /// refused, or a transport-level IO error.
-    // TODO: The message says "Patch check request" even when the failure is a
-    // download or event report.
     Transport,
 }
 
 impl std::fmt::Display for NetworkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // These messages are not shown to end users — they surface only in logs
-        // and the server-bound failure diagnostic event.
+        // and the server-bound failure diagnostic event. They must stay generic
+        // across all network operations (patch check, download, event report).
         match self {
             NetworkError::Server { status } => write!(f, "Request failed with status: {status}"),
             NetworkError::Transport => {
-                write!(f, "Patch check request failed due to network error.")
+                write!(
+                    f,
+                    "Network request failed; the server could not be reached."
+                )
             }
         }
     }
@@ -517,7 +519,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Patch check request failed due to network error."
+            "Network request failed; the server could not be reached."
         );
     }
 
@@ -568,7 +570,7 @@ mod tests {
         let error = result.err().unwrap();
         assert_eq!(
             error.to_string(),
-            "Patch check request failed due to network error."
+            "Network request failed; the server could not be reached."
         )
     }
 

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -139,9 +139,6 @@ pub fn report_event_default(url: &str, request: CreatePatchEventRequest) -> anyh
     Ok(())
 }
 
-/// Handles the result of a network request, returning the response if it was
-/// successful, an error if it was not, or a special error if the network
-/// request failed due to a lack of internet connection.
 /// A typed network-layer failure.
 ///
 /// Preserving the failure as a concrete type (rather than a `bail!`-ed string)
@@ -164,20 +161,22 @@ pub(crate) enum NetworkError {
 
 impl std::fmt::Display for NetworkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Messages are preserved verbatim from the previous `bail!` strings so
-        // existing user-visible text and telemetry payloads do not change.
+        // These messages are not shown to end users — they surface only in logs
+        // and the server-bound failure diagnostic event.
         match self {
             NetworkError::Server { status } => write!(f, "Request failed with status: {status}"),
-            NetworkError::Transport => write!(
-                f,
-                "Patch check request failed due to network error. Please check your internet connection."
-            ),
+            NetworkError::Transport => {
+                write!(f, "Patch check request failed due to network error.")
+            }
         }
     }
 }
 
 impl std::error::Error for NetworkError {}
 
+/// Maps a raw `ureq` result into our typed [`NetworkError`] (or preserves the
+/// underlying `ureq` error for the uncommon cases), returning the response on
+/// success.
 fn handle_network_result(
     result: Result<ureq::http::Response<ureq::Body>, ureq::Error>,
 ) -> anyhow::Result<ureq::http::Response<ureq::Body>> {
@@ -493,7 +492,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Patch check request failed due to network error. Please check your internet connection."
+            "Patch check request failed due to network error."
         );
     }
 
@@ -541,7 +540,10 @@ mod tests {
 
         assert!(result.is_err());
         let error = result.err().unwrap();
-        assert_eq!(error.to_string(), "Patch check request failed due to network error. Please check your internet connection.")
+        assert_eq!(
+            error.to_string(),
+            "Patch check request failed due to network error."
+        )
     }
 
     #[test]

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -142,21 +142,51 @@ pub fn report_event_default(url: &str, request: CreatePatchEventRequest) -> anyh
 /// Handles the result of a network request, returning the response if it was
 /// successful, an error if it was not, or a special error if the network
 /// request failed due to a lack of internet connection.
+/// A typed network-layer failure.
+///
+/// Preserving the failure as a concrete type (rather than a `bail!`-ed string)
+/// lets the failure classifier in `updater.rs` distinguish "the server answered
+/// with an error status" from "we never reached the server". This is internal
+/// enabling work for the categorized-failure surface planned in the
+/// `shorebird_code_push` v3 PRD (Change #7: sealed `Failed{category, code,
+/// retryable}`). It is intentionally *not* exposed across the C ABI — the FFI
+/// still flattens every failure to `SHOREBIRD_UPDATE_ERROR` today.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NetworkError {
+    /// The server was reached but responded with a non-success HTTP status.
+    Server { status: u16 },
+    /// The request never reached the server: offline, DNS failure, connection
+    /// refused, or a transport-level IO error.
+    // TODO: The message says "Patch check request" even when the failure is a
+    // download or event report.
+    Transport,
+}
+
+impl std::fmt::Display for NetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Messages are preserved verbatim from the previous `bail!` strings so
+        // existing user-visible text and telemetry payloads do not change.
+        match self {
+            NetworkError::Server { status } => write!(f, "Request failed with status: {status}"),
+            NetworkError::Transport => write!(
+                f,
+                "Patch check request failed due to network error. Please check your internet connection."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for NetworkError {}
+
 fn handle_network_result(
     result: Result<ureq::http::Response<ureq::Body>, ureq::Error>,
 ) -> anyhow::Result<ureq::http::Response<ureq::Body>> {
     match result {
         Ok(response) => Ok(response),
-        Err(ureq::Error::StatusCode(code)) => {
-            bail!("Request failed with status: {}", code)
-        }
+        Err(ureq::Error::StatusCode(code)) => Err(NetworkError::Server { status: code }.into()),
         Err(ureq::Error::HostNotFound)
         | Err(ureq::Error::ConnectionFailed)
-        | Err(ureq::Error::Io(_)) => {
-            // TODO: This message says "Patch check request" even when the
-            // failure is a download or event report.
-            bail!("Patch check request failed due to network error. Please check your internet connection.");
-        }
+        | Err(ureq::Error::Io(_)) => Err(NetworkError::Transport.into()),
         Err(e) => bail!(e),
     }
 }

--- a/library/src/network.rs
+++ b/library/src/network.rs
@@ -399,6 +399,7 @@ mod tests {
             identifier: EventType::PatchInstallSuccess,
             timestamp: 1234,
             message: None,
+            failure_category: None,
         };
         let request = super::CreatePatchEventRequest { event };
         let json_string = serde_json::to_string(&request).unwrap();
@@ -406,6 +407,29 @@ mod tests {
             json_string,
             r#"{"event":{"app_id":"app_id","arch":"arch","client_id":"client_id","type":"__patch_install__","patch_number":1,"platform":"platform","release_version":"release_version","timestamp":1234,"message":null}}"#
         )
+    }
+
+    #[test]
+    fn create_patch_event_request_serializes_with_failure_category() {
+        // Locks the wire key (`failure_category`) the server reads. When None,
+        // the field is omitted entirely (see the other serialization tests).
+        let event = PatchEvent {
+            app_id: "app_id".to_string(),
+            client_id: "client_id".to_string(),
+            arch: "arch".to_string(),
+            patch_number: 1,
+            platform: "platform".to_string(),
+            release_version: "release_version".to_string(),
+            identifier: EventType::PatchUpdateFailure,
+            timestamp: 1234,
+            message: Some("update_failure: patch 1 failed (...)".to_string()),
+            failure_category: Some("network".to_string()),
+        };
+        let json_string = serde_json::to_string(&event).unwrap();
+        assert!(
+            json_string.contains(r#""failure_category":"network""#),
+            "expected failure_category in: {json_string}"
+        );
     }
 
     #[test]
@@ -420,6 +444,7 @@ mod tests {
             identifier: EventType::PatchInstallSuccess,
             timestamp: 1234,
             message: Some("hello".to_string()),
+            failure_category: None,
         };
         let request = super::CreatePatchEventRequest { event };
         let json_string = serde_json::to_string(&request).unwrap();
@@ -530,6 +555,7 @@ mod tests {
             identifier: EventType::PatchInstallSuccess,
             timestamp: time::unix_timestamp(),
             message: None,
+            failure_category: None,
         };
         let result = super::report_event_default(
             // Make the request to a non-existent URL, which will trigger the
@@ -563,6 +589,7 @@ mod tests {
                     identifier: EventType::PatchInstallSuccess,
                     timestamp: time::unix_timestamp(),
                     message: None,
+                    failure_category: None,
                 },
             },
         );

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -4386,12 +4386,33 @@ mod failure_classification_tests {
     }
 
     #[test]
-    fn codes_and_retryability() {
-        assert_eq!(FailureCategory::Network.code(), "network");
-        assert_eq!(FailureCategory::CorruptPatch.code(), "corrupt_patch");
-        assert!(FailureCategory::Network.retryable());
-        assert!(FailureCategory::Server.retryable());
-        assert!(!FailureCategory::OutOfSpace.retryable());
-        assert!(!FailureCategory::CorruptPatch.retryable());
+    fn codes_and_retryability_cover_all_categories() {
+        use FailureCategory::*;
+        // Exhaustive: every variant's stable code string and retryable flag.
+        let cases = [
+            (Network, "network", true),
+            (Server, "server", true),
+            (OutOfSpace, "out_of_space", false),
+            (PermissionDenied, "permission_denied", false),
+            (Filesystem, "filesystem", false),
+            (CorruptPatch, "corrupt_patch", false),
+            (Unknown, "unknown", true),
+        ];
+        for (category, code, retryable) in cases {
+            assert_eq!(category.code(), code, "code for {category:?}");
+            assert_eq!(
+                category.retryable(),
+                retryable,
+                "retryable for {category:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn corrupt_patch_error_displays() {
+        assert_eq!(
+            UpdateError::CorruptPatch.to_string(),
+            "Downloaded patch was invalid"
+        );
     }
 }

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::file_errors::{FileOperation, IoResultExt};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use dyn_clone::DynClone;
 
 use crate::cache::lifecycle::{self, BadReason, DownloadAction, SkipReason};
@@ -98,6 +98,11 @@ pub enum UpdateError {
     FailedToSaveState,
     ConfigNotInitialized,
     UpdateAlreadyInProgress,
+    /// A patch was downloaded but could not be turned into a usable artifact:
+    /// its bytes failed to decompress, or the installed result did not match
+    /// the expected hash. Distinct from a transient download failure — this is
+    /// deterministic for the given patch on this device.
+    CorruptPatch,
 }
 
 impl std::error::Error for UpdateError {}
@@ -112,8 +117,105 @@ impl Display for UpdateError {
             UpdateError::UpdateAlreadyInProgress => {
                 write!(f, "Update already in progress")
             }
+            UpdateError::CorruptPatch => write!(f, "Downloaded patch was invalid"),
         }
     }
+}
+
+/// A coarse, stable classification of an update failure.
+///
+/// This is internal enabling work for the categorized-failure surface planned
+/// in the `shorebird_code_push` v3 PRD (Change #7: a sealed
+/// `Failed{category, code, retryable}` with telemetry-stable `code` strings).
+/// It is deliberately kept *off* the C ABI for now: the FFI already flattens
+/// every failure to `SHOREBIRD_UPDATE_ERROR`, and v3 will expose categories via
+/// a new structured-result symbol rather than by overloading the existing one
+/// (which the PRD rules out as a transitional shape). Today this is consumed
+/// only to enrich the server-bound failure diagnostic event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureCategory {
+    /// Never reached the server (offline, DNS, connection, transport IO).
+    Network,
+    /// The server was reached but responded with an error, or the response was
+    /// unusable.
+    Server,
+    /// The device is out of storage.
+    OutOfSpace,
+    /// The updater lacks a filesystem permission it needs.
+    PermissionDenied,
+    /// A filesystem error that is neither out-of-space nor permission-related.
+    Filesystem,
+    /// A downloaded patch failed to decompress or did not match its hash.
+    CorruptPatch,
+    /// Not yet classified.
+    Unknown,
+}
+
+impl FailureCategory {
+    /// A short, stable identifier safe to use as a telemetry key. These strings
+    /// are a contract with our dashboards — treat them as append-only.
+    pub fn code(self) -> &'static str {
+        match self {
+            FailureCategory::Network => "network",
+            FailureCategory::Server => "server",
+            FailureCategory::OutOfSpace => "out_of_space",
+            FailureCategory::PermissionDenied => "permission_denied",
+            FailureCategory::Filesystem => "filesystem",
+            FailureCategory::CorruptPatch => "corrupt_patch",
+            FailureCategory::Unknown => "unknown",
+        }
+    }
+
+    /// Whether retrying the update later is likely to succeed without any user
+    /// or developer intervention. Transient (network/server) failures are
+    /// retryable and auto-retried on the next launch; local-state failures are
+    /// not. This is the signal behind v3's customer-facing `retryable` axis.
+    pub fn retryable(self) -> bool {
+        match self {
+            FailureCategory::Network | FailureCategory::Server => true,
+            FailureCategory::OutOfSpace
+            | FailureCategory::PermissionDenied
+            | FailureCategory::Filesystem
+            | FailureCategory::CorruptPatch => false,
+            // Be conservative: an unclassified failure might be transient. A
+            // genuinely permanent one will simply fail again and re-report.
+            FailureCategory::Unknown => true,
+        }
+    }
+}
+
+/// Classifies an update failure by walking the `anyhow` error chain for the
+/// typed errors our origins attach. Unambiguous OS error kinds win regardless
+/// of which layer raised them, so e.g. a disk-full while inflating a patch is
+/// reported as `OutOfSpace` rather than `CorruptPatch`.
+pub fn classify_failure(err: &anyhow::Error) -> FailureCategory {
+    // 1. Unambiguous OS error kinds, wherever in the chain they occurred.
+    if let Some(io) = err.downcast_ref::<std::io::Error>() {
+        match io.kind() {
+            std::io::ErrorKind::StorageFull => return FailureCategory::OutOfSpace,
+            std::io::ErrorKind::PermissionDenied => return FailureCategory::PermissionDenied,
+            _ => {}
+        }
+    }
+    // 2. Our own typed errors.
+    if let Some(net) = err.downcast_ref::<crate::network::NetworkError>() {
+        return match net {
+            crate::network::NetworkError::Server { .. } => FailureCategory::Server,
+            crate::network::NetworkError::Transport => FailureCategory::Network,
+        };
+    }
+    if let Some(update_err) = err.downcast_ref::<UpdateError>() {
+        return match update_err {
+            UpdateError::BadServerResponse => FailureCategory::Server,
+            UpdateError::CorruptPatch => FailureCategory::CorruptPatch,
+            _ => FailureCategory::Unknown,
+        };
+    }
+    // 3. Any remaining IO error is a generic filesystem problem.
+    if err.downcast_ref::<std::io::Error>().is_some() {
+        return FailureCategory::Filesystem;
+    }
+    FailureCategory::Unknown
 }
 
 // `AppConfig` is the rust API.
@@ -333,15 +435,14 @@ fn check_hash(path: &Path, expected_string: &str) -> anyhow::Result<()> {
     // server only send updates when the hash matches.
     // https://github.com/shorebirdtech/updater/issues/56
     if !hash_matches {
-        bail!(
+        // Tag as `CorruptPatch` (via context) so the failure classifier can
+        // categorize it; the detailed, developer-facing message is preserved.
+        return Err(UpdateError::CorruptPatch).context(format!(
             "Update rejected: hash mismatch. Update was downloaded but \
             contents did not match the expected hash. This is most often \
             caused by using the same version number with a different app \
-            binary. Path: {:?}, expected: {}, got: {}",
-            path,
-            expected_string,
-            hash
-        );
+            binary. Path: {path:?}, expected: {expected_string}, got: {hash}"
+        ));
     }
     shorebird_debug!("Hash match: {:?}", path);
     Ok(())
@@ -460,9 +561,14 @@ fn update_internal(_: &UpdaterLockState, channel: Option<&str>) -> anyhow::Resul
         // Queue a diagnostic event for the failed update attempt.
         // This captures download failures, inflate errors, hash mismatches,
         // and install failures — all of which are otherwise invisible.
+        // The category is a stable, low-cardinality key for server-side
+        // telemetry; it is derived here (not over the FFI) so we get
+        // categorized failure reporting with no C ABI change.
+        let category = classify_failure(err);
         let message = format!(
-            "update_failure: patch {} failed ({})",
+            "update_failure: patch {} failed [{}] ({})",
             patch_number,
+            category.code(),
             truncate_error_message(err)
         );
         let queue_result = with_mut_state(|state| {
@@ -547,11 +653,12 @@ fn download_and_install_patch(
         if let Some(expected) = dl_result.content_length {
             if dl_result.total_bytes != expected {
                 let _ = with_mut_state(|state| state.uninstall_patch(patch.number));
-                bail!(
-                    "Download size mismatch: expected {} bytes, got {}",
-                    expected,
+                // Server declared a Content-Length it did not deliver: a server
+                // contract violation, tagged so the classifier reports `Server`.
+                return Err(UpdateError::BadServerResponse).context(format!(
+                    "Download size mismatch: expected {expected} bytes, got {}",
                     dl_result.total_bytes
-                );
+                ));
             }
         }
 
@@ -588,6 +695,9 @@ fn install_downloaded_patch(
     let patch_base_rs = patch_base(config)?;
     if let Err(e) = inflate(download_path, patch_base_rs, &installed_path) {
         // Inflate failed — bytes won't decompress. Deterministically bad.
+        // The error is returned as-is (message-preserving): content problems are
+        // already tagged `CorruptPatch` inside `validate_compressed_patch`, and a
+        // disk-full/permission IO cause stays downcastable for classification.
         mark_patch_bad(patch.number, BadReason::InvalidPatchBytes);
         return Err(e);
     }
@@ -694,16 +804,19 @@ fn validate_compressed_patch(patch_path: &Path) -> anyhow::Result<()> {
     let metadata =
         fs::metadata(patch_path).with_file_context(FileOperation::GetMetadata, patch_path)?;
     let size = metadata.len();
+    // These are content-corruption failures: the bytes we received are not a
+    // usable patch. Tag each as `CorruptPatch` (as an inner marker, via
+    // `.context`) so the failure classifier can categorize it while the
+    // detailed, developer-facing message stays the top-level `Display`.
     if size == 0 {
-        bail!("Downloaded patch file is empty: {:?}", patch_path);
+        return Err(UpdateError::CorruptPatch)
+            .context(format!("Downloaded patch file is empty: {patch_path:?}"));
     }
     // A valid zstd frame is at least 4 bytes (magic number).
     if size < 4 {
-        bail!(
-            "Downloaded patch file is too small ({} bytes) to be a valid zstd archive: {:?}",
-            size,
-            patch_path
-        );
+        return Err(UpdateError::CorruptPatch).context(format!(
+            "Downloaded patch file is too small ({size} bytes) to be a valid zstd archive: {patch_path:?}"
+        ));
     }
     let mut file =
         fs::File::open(patch_path).with_file_context(FileOperation::ReadFile, patch_path)?;
@@ -711,13 +824,10 @@ fn validate_compressed_patch(patch_path: &Path) -> anyhow::Result<()> {
     file.read_exact(&mut magic)
         .with_file_context(FileOperation::ReadFile, patch_path)?;
     if magic != ZSTD_MAGIC {
-        bail!(
+        return Err(UpdateError::CorruptPatch).context(format!(
             "Downloaded patch file does not have valid zstd magic bytes \
-            (expected {:02x?}, got {:02x?}). The download may be corrupt: {:?}",
-            ZSTD_MAGIC,
-            magic,
-            patch_path
-        );
+            (expected {ZSTD_MAGIC:02x?}, got {magic:02x?}). The download may be corrupt: {patch_path:?}"
+        ));
     }
     Ok(())
 }
@@ -4184,5 +4294,94 @@ mod patch_check_current_patch_number_tests {
         // 1 = running patch sent; -1 = field omitted (the bug); i64::MIN = hook never ran.
         assert_eq!(CAPTURED.load(Ordering::SeqCst), 1);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod failure_classification_tests {
+    use super::{classify_failure, FailureCategory, UpdateError};
+    use crate::network::NetworkError;
+    use std::io::{Error as IoError, ErrorKind};
+
+    #[test]
+    fn io_out_of_space_and_permission_win() {
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(IoError::from(ErrorKind::StorageFull))),
+            FailureCategory::OutOfSpace
+        );
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(IoError::from(
+                ErrorKind::PermissionDenied
+            ))),
+            FailureCategory::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn network_errors_classify() {
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(NetworkError::Transport)),
+            FailureCategory::Network
+        );
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(NetworkError::Server { status: 503 })),
+            FailureCategory::Server
+        );
+    }
+
+    #[test]
+    fn update_errors_classify() {
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(UpdateError::BadServerResponse)),
+            FailureCategory::Server
+        );
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(UpdateError::CorruptPatch)),
+            FailureCategory::CorruptPatch
+        );
+    }
+
+    #[test]
+    fn os_error_kind_beats_corrupt_patch_tag() {
+        // A disk-full while inflating is tagged CorruptPatch but must report
+        // OutOfSpace — the underlying OS kind takes priority.
+        let err = anyhow::Error::new(IoError::from(ErrorKind::StorageFull))
+            .context(UpdateError::CorruptPatch);
+        assert_eq!(classify_failure(&err), FailureCategory::OutOfSpace);
+    }
+
+    #[test]
+    fn generic_io_is_filesystem() {
+        assert_eq!(
+            classify_failure(&anyhow::Error::new(IoError::from(ErrorKind::NotFound))),
+            FailureCategory::Filesystem
+        );
+    }
+
+    #[test]
+    fn untyped_error_is_unknown() {
+        assert_eq!(
+            classify_failure(&anyhow::anyhow!("something went wrong")),
+            FailureCategory::Unknown
+        );
+    }
+
+    #[test]
+    fn context_wrapping_preserves_classification() {
+        // Extra `.context()` layers (as added at real origins) must not defeat
+        // downcast-based classification.
+        let err = anyhow::Error::new(NetworkError::Server { status: 500 })
+            .context("while checking for a patch");
+        assert_eq!(classify_failure(&err), FailureCategory::Server);
+    }
+
+    #[test]
+    fn codes_and_retryability() {
+        assert_eq!(FailureCategory::Network.code(), "network");
+        assert_eq!(FailureCategory::CorruptPatch.code(), "corrupt_patch");
+        assert!(FailureCategory::Network.retryable());
+        assert!(FailureCategory::Server.retryable());
+        assert!(!FailureCategory::OutOfSpace.retryable());
+        assert!(!FailureCategory::CorruptPatch.retryable());
     }
 }

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -561,24 +561,26 @@ fn update_internal(_: &UpdaterLockState, channel: Option<&str>) -> anyhow::Resul
         // Queue a diagnostic event for the failed update attempt.
         // This captures download failures, inflate errors, hash mismatches,
         // and install failures — all of which are otherwise invisible.
-        // The category is a stable, low-cardinality key for server-side
-        // telemetry; it is derived here (not over the FFI) so we get
-        // categorized failure reporting with no C ABI change.
+        // The category is sent as a structured field (not baked into the
+        // message string) so the server can consume it directly; it is derived
+        // here rather than over the FFI, so we get categorized failure
+        // reporting with no C ABI change.
         let category = classify_failure(err);
         let message = format!(
-            "update_failure: patch {} failed [{}] ({})",
+            "update_failure: patch {} failed ({})",
             patch_number,
-            category.code(),
             truncate_error_message(err)
         );
         let queue_result = with_mut_state(|state| {
-            state.queue_event(PatchEvent::new(
+            let mut event = PatchEvent::new(
                 &config,
                 EventType::PatchUpdateFailure,
                 patch_number,
                 state.client_id(),
                 Some(&message),
-            ))
+            );
+            event.failure_category = Some(category.code().to_string());
+            state.queue_event(event)
         });
         if let Err(queue_err) = queue_result {
             shorebird_error!("Failed to queue update failure event: {:?}", queue_err);
@@ -2160,6 +2162,7 @@ patch_verification: bogus_mode
                 release_version: config.release_version.clone(),
                 timestamp: time::unix_timestamp(),
                 message: Some("engine_report: patch 1 failed to launch".to_string()),
+                failure_category: None,
             };
             // Queue 5 events.
             assert!(state.queue_event(fail_event.clone()).is_ok());

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -2322,6 +2322,13 @@ patch_verification: bogus_mode
                 message.contains("Download size mismatch"),
                 "message should contain error detail: {message}"
             );
+            // A size mismatch is a server contract violation, so the event
+            // carries the structured `server` category (not baked into message).
+            assert_eq!(
+                events[0].failure_category.as_deref(),
+                Some("server"),
+                "expected server category on the failure event"
+            );
             Ok(())
         })?;
 


### PR DESCRIPTION
## What

Adds internal, typed classification of update failures in the Rust updater. Today every failure is flattened to `SHOREBIRD_UPDATE_ERROR` at the FFI boundary, which is why the Dart `UpdateFailureReason` collapses network / permission / disk-full / server failures all into `unknown`. This change recovers that information **below** the FFI boundary.

- New `FailureCategory` enum (`Network`, `Server`, `OutOfSpace`, `PermissionDenied`, `Filesystem`, `CorruptPatch`, `Unknown`) with a stable `code()` (telemetry key) and a `retryable()` mapping.
- New `classify_failure(&anyhow::Error)` that walks the error chain by downcast. **Unambiguous OS error kinds win first**, so a disk-full while inflating a patch reports `OutOfSpace`, not `CorruptPatch`.

To make classification reliable, error origins now **preserve typed causes** instead of flattening to strings:
- `network.rs`: `handle_network_result` returns a typed `NetworkError` (`Server { status }` vs `Transport`) rather than `bail!`-ing a string. **Messages are preserved verbatim.**
- `updater.rs`: adds `UpdateError::CorruptPatch`, tagging hash-mismatch, zstd-validation, and download-size-mismatch failures. Tags are attached as **inner markers** (via `.context`) so the detailed, developer-facing message stays the top-level `Display` — no user-visible or telemetry message text changes.

## The payoff (no C ABI change)

The category is consumed only to enrich the existing server-bound failure diagnostic event:

```
update_failure: patch 42 failed [corrupt_patch] (Downloaded patch was invalid: ...)
```

So we get categorized failure telemetry **immediately, with zero FFI/Dart/header changes** (verified: the diff touches only `network.rs` and `updater.rs`).

## Why not expose new FFI error codes

This is deliberately kept off the C ABI. The `shorebird_code_push` v3 PRD plans a customer-facing `Failed{category, code, retryable}` (Change #7), exposed via a **new structured-result C symbol**, and explicitly rejects transitional 2.x FFI shapes ("we go straight to 3.0") since every Rust C symbol is a permanent contract. This PR is the **enabling layer** for that surface: it proves the taxonomy and the `category → retryable` mapping without spending permanent-contract budget. FFI exposure is deferred to v3.

## Testing

- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check` — all clean.
- `cargo test` — 258 pass, 0 fail. Includes 8 new classifier tests (per-category, the OS-kind-priority ordering, and context-wrapping preservation).

## Notes / out of scope

- Pre-existing: `NetworkError::Transport`'s message still says "Patch check request…" even for download/event failures (TODO preserved). Easy to fix here if desired.