### PR TITLE
feat: add hot restart request API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,9 +1020,9 @@ checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
 
 [[package]]
 name = "mockall"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+checksum = "1a6ceddfe3ce334925e96bf420fdb2dcee5bed6c632a168ece622676dadeaf8a"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+checksum = "9cfe16fbe8a314aeec0b861ac24e60b1e123e97634bab045475b9d6a18416fd8"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/docs/hot_restart.md
+++ b/docs/hot_restart.md
@@ -1,0 +1,63 @@
+# Hot restart
+
+Hot restart applies a downloaded patch without the user relaunching the app:
+the Flutter engine tears down the running Dart isolate and boots a fresh one
+from the next boot patch, inside the same OS process.
+
+## Who does what
+
+The updater cannot restart the Dart VM — only the engine can. The updater's
+role is to relay the request and to keep its boot bookkeeping correct across
+more than one launch cycle per process.
+
+```
+package:shorebird_code_push          updater (Rust)              Shorebird engine (C++)
+----------------------------         --------------              ----------------------
+ShorebirdUpdater.restartApp()
+  └─ shorebird_restart_app() ──────► restart::request_restart()
+                                       └─ registered handler ──► restart host
+                                                                   ├─ resolves next boot patch
+                                                                   ├─ begins new launch cycle
+                                                                   │   (report_launch_start)
+                                                                   ├─ relaunches root isolate
+                                                                   │   from the patch snapshot
+                                                                   └─ report_launch_success /
+                                                                      report_launch_failure
+```
+
+- `shorebird_set_restart_handler` (engine C surface, `c_api/engine.rs`):
+  the engine registers a handler at startup. The handler returns `true` if
+  it accepted and scheduled a restart.
+- `shorebird_restart_app` (Dart C surface, `c_api/dart.rs`): called by
+  `package:shorebird_code_push`. Returns `false` when no handler is
+  registered — old engines, debug builds, or unsupported configurations.
+- `library/src/restart.rs`: the relay between the two.
+
+## The second launch cycle
+
+A hot restart is, from the updater's perspective, simply a second
+`report_launch_start` → `report_launch_success`/`report_launch_failure`
+cycle in the same process:
+
+- `report_launch_start` re-reads `next_boot_patch`, updates the in-memory
+  `running_patch`, and records `currently_booting_patch` on disk. If the
+  process dies mid-restart, the next cold boot's crash recovery marks the
+  patch bad — the same protection cold boots get.
+- `report_launch_failure` marks the patch bad and falls back, so the
+  engine's recovery relaunch boots something known-good.
+- `report_launch_success` records the patch as last booted and reports the
+  install event.
+
+The once-per-process guarding of these calls lives in the *engine*
+(`shell/common/shorebird/updater.cc`), not in Rust; the engine's restart
+host resets those guards when it intentionally starts a new launch cycle.
+See `hot_restart_tests` in `library/src/updater.rs` for the contract.
+
+## Testing
+
+- `library/src/restart.rs` — relay unit tests.
+- `library/src/updater.rs` (`hot_restart_tests`) — second-launch-cycle
+  contract.
+- `shorebird_code_push/test/integration/all_test.dart` — full FFI round
+  trip against the real Rust library via `library_test_hooks`' fake
+  restart handler.

--- a/library/include/updater_dart.h
+++ b/library/include/updater_dart.h
@@ -106,6 +106,20 @@ const struct UpdateResult *shorebird_update_with_result(const char *c_channel);
  */
 SHOREBIRD_EXPORT void shorebird_free_update_result(struct UpdateResult *result);
 
+/**
+ * Requests that the Flutter engine restart the app's Dart code without
+ * killing the host process, booting from whatever patch the updater has
+ * selected as the next boot patch (or the base release if none). This is
+ * how a downloaded patch is applied without the user relaunching the app.
+ *
+ * Returns true if the engine accepted the request and will restart
+ * momentarily; Dart code continues running until the restart begins, so
+ * callers should not assume execution stops at this call. Returns false if
+ * restarting is not supported (engine too old, debug build, or an
+ * unsupported engine configuration such as multiple concurrent engines).
+ */
+SHOREBIRD_EXPORT bool shorebird_restart_app(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/library/include/updater_engine.h
+++ b/library/include/updater_engine.h
@@ -144,6 +144,16 @@ SHOREBIRD_EXPORT void shorebird_report_launch_failure(void);
  */
 SHOREBIRD_EXPORT void shorebird_report_launch_success(void);
 
+/**
+ * Registers the engine's restart handler, used to service
+ * `shorebird_restart_app` requests from `package:shorebird_code_push`.
+ * The handler must tear down and relaunch the app's Dart isolate, loading
+ * the current next-boot patch, and return true if the restart was
+ * scheduled. Pass null to unregister (e.g. if the last engine capable of
+ * restarting is destroyed).
+ */
+SHOREBIRD_EXPORT void shorebird_set_restart_handler(bool (*handler)(void));
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/library/src/c_api/dart.rs
+++ b/library/src/c_api/dart.rs
@@ -136,3 +136,18 @@ pub unsafe extern "C" fn shorebird_free_update_result(result: *mut UpdateResult)
     let result = unsafe { Box::from_raw(result) };
     unsafe { free_c_string(result.message) };
 }
+
+/// Requests that the Flutter engine restart the app's Dart code without
+/// killing the host process, booting from whatever patch the updater has
+/// selected as the next boot patch (or the base release if none). This is
+/// how a downloaded patch is applied without the user relaunching the app.
+///
+/// Returns true if the engine accepted the request and will restart
+/// momentarily; Dart code continues running until the restart begins, so
+/// callers should not assume execution stops at this call. Returns false if
+/// restarting is not supported (engine too old, debug build, or an
+/// unsupported engine configuration such as multiple concurrent engines).
+#[no_mangle]
+pub extern "C" fn shorebird_restart_app() -> bool {
+    crate::restart::request_restart()
+}

--- a/library/src/c_api/engine.rs
+++ b/library/src/c_api/engine.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 
 use super::{allocate_c_string, free_c_string, log_on_error, to_rust};
 use crate::c_api::c_file::CFileProvider;
+use crate::restart;
 use crate::updater;
 
 /// Struct containing configuration parameters for the updater.
@@ -217,4 +218,15 @@ pub extern "C" fn shorebird_report_launch_success() {
         "reporting launch success",
         (),
     );
+}
+
+/// Registers the engine's restart handler, used to service
+/// `shorebird_restart_app` requests from `package:shorebird_code_push`.
+/// The handler must tear down and relaunch the app's Dart isolate, loading
+/// the current next-boot patch, and return true if the restart was
+/// scheduled. Pass null to unregister (e.g. if the last engine capable of
+/// restarting is destroyed).
+#[no_mangle]
+pub extern "C" fn shorebird_set_restart_handler(handler: Option<extern "C" fn() -> bool>) {
+    restart::set_restart_handler(handler);
 }

--- a/library/src/config.rs
+++ b/library/src/config.rs
@@ -65,6 +65,7 @@ pub fn testing_reset_config() {
         *config = None;
     });
     set_running_patch_number(None);
+    crate::restart::set_restart_handler(None);
 }
 
 pub fn check_initialized_and_call<F, R>(

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -15,6 +15,7 @@ mod events;
 mod file_errors;
 mod logging;
 mod network;
+mod restart;
 mod time;
 mod updater;
 mod updater_lock;

--- a/library/src/restart.rs
+++ b/library/src/restart.rs
@@ -1,0 +1,86 @@
+// Support for restarting the running app to boot a newly installed patch
+// without killing the host process ("hot restart" of production apps).
+//
+// The updater itself cannot restart the Dart VM — only the Flutter engine
+// can tear down and relaunch the root isolate. Instead, the engine registers
+// a restart handler at startup (via `shorebird_set_restart_handler` on the
+// engine C surface), and `package:shorebird_code_push` requests a restart
+// over FFI (via `shorebird_restart_app` on the Dart C surface). This module
+// is the relay between the two.
+
+use std::sync::Mutex;
+
+/// Handler installed by the Flutter engine. Returns true if the engine
+/// accepted the request and scheduled a restart.
+pub type RestartHandler = extern "C" fn() -> bool;
+
+static RESTART_HANDLER: Mutex<Option<RestartHandler>> = Mutex::new(None);
+
+/// Installs (or clears, with `None`) the engine's restart handler.
+pub fn set_restart_handler(handler: Option<RestartHandler>) {
+    let mut lock = RESTART_HANDLER.lock().unwrap();
+    *lock = handler;
+}
+
+/// Asks the engine to restart the app. Returns true if a handler was
+/// installed and it accepted the request. Returns false when no handler is
+/// registered (e.g. running against an engine without hot restart support,
+/// or in a debug build where the updater is not attached to an engine).
+pub fn request_restart() -> bool {
+    // Copy the handler out of the lock before invoking it so a slow or
+    // re-entrant handler cannot deadlock against set_restart_handler.
+    let handler = *RESTART_HANDLER.lock().unwrap();
+    match handler {
+        Some(handler) => handler(),
+        None => {
+            shorebird_warn!("Restart requested, but no restart handler is registered.");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // The handler registry is process-global state, so these tests are
+    // serialized and each test leaves the handler cleared.
+
+    static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    extern "C" fn accepting_handler() -> bool {
+        CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+        true
+    }
+
+    extern "C" fn rejecting_handler() -> bool {
+        CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+        false
+    }
+
+    #[test]
+    #[serial(restart_handler)]
+    fn request_restart_without_handler_returns_false() {
+        super::set_restart_handler(None);
+        assert!(!super::request_restart());
+    }
+
+    #[test]
+    #[serial(restart_handler)]
+    fn request_restart_invokes_handler_and_relays_result() {
+        CALL_COUNT.store(0, Ordering::SeqCst);
+
+        super::set_restart_handler(Some(accepting_handler));
+        assert!(super::request_restart());
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
+
+        super::set_restart_handler(Some(rejecting_handler));
+        assert!(!super::request_restart());
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 2);
+
+        super::set_restart_handler(None);
+        assert!(!super::request_restart());
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 2);
+    }
+}

--- a/library/src/updater.rs
+++ b/library/src/updater.rs
@@ -4186,3 +4186,108 @@ mod patch_check_current_patch_number_tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod hot_restart_tests {
+    use anyhow::Result;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    use crate::{
+        network::{testing_set_network_hooks, PatchCheckResponse, UNEXPECTED_DOWNLOAD},
+        report_launch_failure, report_launch_start, report_launch_success, running_patch,
+        test_utils::install_fake_patch,
+        updater::tests::init_for_testing,
+        with_mut_state,
+    };
+
+    fn set_noop_network_hooks() {
+        testing_set_network_hooks(
+            |_url, _request| {
+                Ok(PatchCheckResponse {
+                    patch_available: false,
+                    patch: None,
+                    rolled_back_patch_numbers: None,
+                })
+            },
+            UNEXPECTED_DOWNLOAD,
+            |_url, _event| Ok(()),
+        );
+    }
+
+    /// Hot restart runs a second launch cycle (start → success) within one
+    /// process. This is the updater-side contract the engine's hot restart
+    /// relies on: after the second cycle, the in-memory `running_patch`
+    /// reflects the patch that was just booted, and the on-disk pointers
+    /// record it as last booted.
+    #[serial]
+    #[test]
+    fn second_launch_cycle_adopts_new_patch() -> Result<()> {
+        let tmp_dir = TempDir::new().unwrap();
+        init_for_testing(&tmp_dir, None);
+        set_noop_network_hooks();
+
+        // Cold boot: no patch installed, running the base release.
+        report_launch_start()?;
+        report_launch_success()?;
+        assert_eq!(running_patch()?.map(|p| p.number), None);
+
+        // A patch is downloaded in the background while the app runs.
+        install_fake_patch(1)?;
+        assert_eq!(running_patch()?.map(|p| p.number), None);
+
+        // Hot restart: the engine begins a fresh launch cycle.
+        report_launch_start()?;
+        assert_eq!(running_patch()?.map(|p| p.number), Some(1));
+        report_launch_success()?;
+
+        with_mut_state(|state| {
+            assert_eq!(
+                state.last_successfully_booted_patch().map(|p| p.number),
+                Some(1)
+            );
+            assert!(state.currently_booting_patch().is_none());
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    /// If the relaunched isolate fails to come up, the engine reports launch
+    /// failure. The patch that was being hot restarted into must be marked
+    /// bad and the next boot must fall back to the previously good patch, so
+    /// the engine's recovery relaunch boots something known-good.
+    #[serial]
+    #[test]
+    fn failed_hot_restart_rolls_back_to_last_good_patch() -> Result<()> {
+        let tmp_dir = TempDir::new().unwrap();
+        init_for_testing(&tmp_dir, None);
+        set_noop_network_hooks();
+
+        // Cold boot onto patch 1 and confirm it as good.
+        install_fake_patch(1)?;
+        report_launch_start()?;
+        report_launch_success()?;
+        assert_eq!(running_patch()?.map(|p| p.number), Some(1));
+
+        // Patch 2 arrives; hot restart into it fails.
+        install_fake_patch(2)?;
+        report_launch_start()?;
+        assert_eq!(running_patch()?.map(|p| p.number), Some(2));
+        report_launch_failure()?;
+
+        with_mut_state(|state| {
+            assert!(state.is_known_bad_patch(2));
+            assert_eq!(state.next_boot_patch().map(|p| p.number), Some(1));
+            Ok(())
+        })?;
+
+        // The engine's recovery relaunch begins another cycle, which lands
+        // back on patch 1.
+        report_launch_start()?;
+        assert_eq!(running_patch()?.map(|p| p.number), Some(1));
+        report_launch_success()?;
+
+        Ok(())
+    }
+}

--- a/library_test_hooks/include/library_test_hooks.h
+++ b/library_test_hooks/include/library_test_hooks.h
@@ -48,6 +48,21 @@ bool shorebird_test_init(const char *app_storage_dir,
  */
 SHOREBIRD_EXPORT void shorebird_test_simulate_successful_launch(void);
 
+/**
+ * Installs a fake engine restart handler, as the Shorebird engine does
+ * at startup. `accept` controls whether the handler reports the restart
+ * as scheduled (the value returned to `shorebird_restart_app` callers).
+ * Also resets the request counter. `shorebird_test_reset` removes the
+ * handler again.
+ */
+SHOREBIRD_EXPORT void shorebird_test_install_restart_handler(bool accept);
+
+/**
+ * The number of restart requests the fake handler has received since it
+ * was last installed.
+ */
+SHOREBIRD_EXPORT uintptr_t shorebird_test_restart_request_count(void);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/library_test_hooks/src/lib.rs
+++ b/library_test_hooks/src/lib.rs
@@ -102,3 +102,35 @@ pub extern "C" fn shorebird_test_simulate_successful_launch() {
     engine::shorebird_report_launch_start();
     engine::shorebird_report_launch_success();
 }
+
+// Fake engine restart handler state. Mirrors what the Shorebird engine
+// does in production: it registers a handler via
+// `shorebird_set_restart_handler` at startup, and `shorebird_restart_app`
+// (called by `package:shorebird_code_push`) relays to it.
+static RESTART_REQUEST_COUNT: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static RESTART_ACCEPT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+extern "C" fn test_restart_handler() -> bool {
+    RESTART_REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    RESTART_ACCEPT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Installs a fake engine restart handler, as the Shorebird engine does
+/// at startup. `accept` controls whether the handler reports the restart
+/// as scheduled (the value returned to `shorebird_restart_app` callers).
+/// Also resets the request counter. `shorebird_test_reset` removes the
+/// handler again.
+#[no_mangle]
+pub extern "C" fn shorebird_test_install_restart_handler(accept: bool) {
+    RESTART_ACCEPT.store(accept, std::sync::atomic::Ordering::SeqCst);
+    RESTART_REQUEST_COUNT.store(0, std::sync::atomic::Ordering::SeqCst);
+    engine::shorebird_set_restart_handler(Some(test_restart_handler));
+}
+
+/// The number of restart requests the fake handler has received since it
+/// was last installed.
+#[no_mangle]
+pub extern "C" fn shorebird_test_restart_request_count() -> usize {
+    RESTART_REQUEST_COUNT.load(std::sync::atomic::Ordering::SeqCst)
+}

--- a/shorebird_code_push/CHANGELOG.md
+++ b/shorebird_code_push/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.1.0
+
+- feat: add `ShorebirdUpdater.restartApp()`, which restarts the app's Dart
+  code in place so a downloaded patch takes effect without the user
+  relaunching the app. Requires an engine with hot restart support; returns
+  `false` (patch still applies on next launch) on older engines.
+
 # 2.0.7
 
 - chore: internal cleanup; no public API changes.

--- a/shorebird_code_push/README.md
+++ b/shorebird_code_push/README.md
@@ -79,6 +79,29 @@ class _MyHomePageState extends State<MyHomePage> {
 
 See the example for a complete working app.
 
+### Applying a patch without relaunching the app
+
+By default, a downloaded patch takes effect the next time the app launches.
+`restartApp()` applies it immediately instead by restarting the app's Dart
+code in place (like a development hot restart: all in-memory state is lost
+and `main()` runs again, but the app itself stays open):
+
+```dart
+final status = await updater.checkForUpdate();
+if (status == UpdateStatus.restartRequired) {
+  // Consider prompting the user first: the app's state resets.
+  final restarting = await updater.restartApp();
+  if (!restarting) {
+    // Hot restart isn't supported here (e.g. an engine that predates it or
+    // an app running multiple Flutter engines). The patch will take effect
+    // on the next app launch instead.
+  }
+}
+```
+
+Requires a Shorebird Flutter version with hot restart support on Android or
+iOS; on anything older `restartApp()` safely returns `false`.
+
 ### Tracks
 
 Shorebird supports publishing patches to different tracks, which can be

--- a/shorebird_code_push/example/lib/main.dart
+++ b/shorebird_code_push/example/lib/main.dart
@@ -142,7 +142,40 @@ class _MyHomePageState extends State<MyHomePage> {
       ..hideCurrentMaterialBanner()
       ..showMaterialBanner(
         MaterialBanner(
-          content: const Text('A new patch is ready! Please restart your app.'),
+          content: const Text('A new patch is ready!'),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                // Restart the app's Dart code so the patch takes effect
+                // immediately. Returns false if hot restart isn't supported
+                // in this environment (e.g. an older engine), in which case
+                // the patch takes effect on the next app launch instead.
+                final restarting = await _updater.restartApp();
+                if (!mounted || restarting) return;
+                _showRestartFailedBanner();
+              },
+              child: const Text('Restart now'),
+            ),
+            TextButton(
+              onPressed: () {
+                ScaffoldMessenger.of(context).hideCurrentMaterialBanner();
+              },
+              child: const Text('Later'),
+            ),
+          ],
+        ),
+      );
+  }
+
+  void _showRestartFailedBanner() {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentMaterialBanner()
+      ..showMaterialBanner(
+        MaterialBanner(
+          content: const Text(
+            'Restarting is not supported here. '
+            'The patch will take effect the next time the app is launched.',
+          ),
           actions: [
             TextButton(
               onPressed: () {

--- a/shorebird_code_push/lib/src/generated/updater_bindings.g.dart
+++ b/shorebird_code_push/lib/src/generated/updater_bindings.g.dart
@@ -2440,6 +2440,25 @@ class UpdaterBindings {
           'shorebird_free_update_result');
   late final _shorebird_free_update_result = _shorebird_free_update_resultPtr
       .asFunction<void Function(ffi.Pointer<UpdateResult>)>();
+
+  /// Requests that the Flutter engine restart the app's Dart code without
+  /// killing the host process, booting from whatever patch the updater has
+  /// selected as the next boot patch (or the base release if none). This is
+  /// how a downloaded patch is applied without the user relaunching the app.
+  ///
+  /// Returns true if the engine accepted the request and will restart
+  /// momentarily; Dart code continues running until the restart begins, so
+  /// callers should not assume execution stops at this call. Returns false if
+  /// restarting is not supported (engine too old, debug build, or an
+  /// unsupported engine configuration such as multiple concurrent engines).
+  bool shorebird_restart_app() {
+    return _shorebird_restart_app();
+  }
+
+  late final _shorebird_restart_appPtr =
+      _lookup<ffi.NativeFunction<ffi.Bool Function()>>('shorebird_restart_app');
+  late final _shorebird_restart_app =
+      _shorebird_restart_appPtr.asFunction<bool Function()>();
 }
 
 typedef __builtin_va_list = ffi.Pointer<ffi.Char>;
@@ -4110,6 +4129,8 @@ const int __MAC_26_3 = 260300;
 
 const int __MAC_26_4 = 260400;
 
+const int __MAC_26_5 = 260500;
+
 const int __IPHONE_2_0 = 20000;
 
 const int __IPHONE_2_1 = 20100;
@@ -4296,6 +4317,8 @@ const int __IPHONE_26_3 = 260300;
 
 const int __IPHONE_26_4 = 260400;
 
+const int __IPHONE_26_5 = 260500;
+
 const int __WATCHOS_1_0 = 10000;
 
 const int __WATCHOS_2_0 = 20000;
@@ -4419,6 +4442,8 @@ const int __WATCHOS_26_2 = 260200;
 const int __WATCHOS_26_3 = 260300;
 
 const int __WATCHOS_26_4 = 260400;
+
+const int __WATCHOS_26_5 = 260500;
 
 const int __TVOS_9_0 = 90000;
 
@@ -4544,6 +4569,8 @@ const int __TVOS_26_3 = 260300;
 
 const int __TVOS_26_4 = 260400;
 
+const int __TVOS_26_5 = 260500;
+
 const int __BRIDGEOS_2_0 = 20000;
 
 const int __BRIDGEOS_3_0 = 30000;
@@ -4622,6 +4649,8 @@ const int __BRIDGEOS_10_3 = 100300;
 
 const int __BRIDGEOS_10_4 = 100400;
 
+const int __BRIDGEOS_26_5 = 260500;
+
 const int __DRIVERKIT_19_0 = 190000;
 
 const int __DRIVERKIT_20_0 = 200000;
@@ -4674,6 +4703,8 @@ const int __DRIVERKIT_25_3 = 250300;
 
 const int __DRIVERKIT_25_4 = 250400;
 
+const int __DRIVERKIT_25_5 = 250500;
+
 const int __VISIONOS_1_0 = 10000;
 
 const int __VISIONOS_1_1 = 10100;
@@ -4707,6 +4738,8 @@ const int __VISIONOS_26_2 = 260200;
 const int __VISIONOS_26_3 = 260300;
 
 const int __VISIONOS_26_4 = 260400;
+
+const int __VISIONOS_26_5 = 260500;
 
 const int MAC_OS_X_VERSION_10_0 = 1000;
 
@@ -4862,6 +4895,8 @@ const int MAC_OS_VERSION_26_3 = 260300;
 
 const int MAC_OS_VERSION_26_4 = 260400;
 
+const int MAC_OS_VERSION_26_5 = 260500;
+
 const int __AVAILABILITY_VERSIONS_VERSION_HASH = 93585900;
 
 const String __AVAILABILITY_VERSIONS_VERSION_STRING = 'Local';
@@ -4870,7 +4905,7 @@ const String __AVAILABILITY_FILE = 'AvailabilityVersions.h';
 
 const int __MAC_OS_X_VERSION_MIN_REQUIRED = 260000;
 
-const int __MAC_OS_X_VERSION_MAX_ALLOWED = 260400;
+const int __MAC_OS_X_VERSION_MAX_ALLOWED = 260500;
 
 const int __ENABLE_LEGACY_MAC_AVAILABILITY = 1;
 

--- a/shorebird_code_push/lib/src/shorebird_updater.dart
+++ b/shorebird_code_push/lib/src/shorebird_updater.dart
@@ -188,6 +188,38 @@ abstract class ShorebirdUpdater {
   /// * [checkForUpdate], which should be called to check if an update is
   ///   available before calling this method.
   Future<void> update({UpdateTrack? track});
+
+  /// Restarts the app's Dart code so the most recently downloaded patch takes
+  /// effect immediately, without the user relaunching the app.
+  ///
+  /// This tears down the running Dart isolate and boots a fresh one from the
+  /// next boot patch (the patch reported by [readNextPatch], or the base
+  /// release if the current patch was rolled back). It is the production
+  /// equivalent of a development-time hot restart: all in-memory Dart state
+  /// is lost and `main()` runs again, while the surrounding platform
+  /// activity/view controller and plugin registrations are preserved.
+  ///
+  /// Returns `true` if the engine accepted the restart request. When this
+  /// returns `true` the restart happens asynchronously — Dart code (including
+  /// code immediately after this call) may continue to run briefly before the
+  /// isolate is torn down, so don't rely on execution stopping here.
+  ///
+  /// Returns `false` when hot restart is not supported in the current
+  /// environment:
+  /// * The updater is not available (see [isAvailable]).
+  /// * The app is running against a Shorebird engine that predates hot
+  ///   restart support.
+  /// * The engine configuration is unsupported (e.g. multiple Flutter engines
+  ///   in one process, as with some add-to-app setups).
+  ///
+  /// When this returns `false`, the downloaded patch still takes effect on
+  /// the next full app launch, so callers can fall back to prompting the user
+  /// to restart the app.
+  ///
+  /// Note: this restarts Dart code even if no new patch is waiting; check
+  /// [checkForUpdate] for [UpdateStatus.restartRequired] before calling this
+  /// if you only want to restart when a patch is pending.
+  Future<bool> restartApp();
 }
 
 /// A track to check for updates on.

--- a/shorebird_code_push/lib/src/shorebird_updater_io.dart
+++ b/shorebird_code_push/lib/src/shorebird_updater_io.dart
@@ -130,6 +130,25 @@ class ShorebirdUpdaterImpl implements ShorebirdUpdater {
       _updater.freeUpdateResult(result);
     }
   }
+
+  @override
+  Future<bool> restartApp() async {
+    if (!_isAvailable) return false;
+
+    // Intentionally not run in a separate isolate: the underlying call only
+    // posts a restart request to the engine's platform thread and returns
+    // immediately, and a helper isolate could be torn down mid-call once the
+    // restart begins.
+    try {
+      return _updater.restartApp();
+      // Catch everything: engines that predate hot restart support don't
+      // export the symbol, which surfaces as an ArgumentError from the
+      // late-bound FFI lookup.
+      // ignore: avoid_catches_without_on_clauses
+    } catch (_) {
+      return false;
+    }
+  }
 }
 
 extension on int {

--- a/shorebird_code_push/lib/src/shorebird_updater_web.dart
+++ b/shorebird_code_push/lib/src/shorebird_updater_web.dart
@@ -24,4 +24,7 @@ class ShorebirdUpdaterImpl implements ShorebirdUpdater {
 
   @override
   Future<void> update({UpdateTrack? track}) async {}
+
+  @override
+  Future<bool> restartApp() async => false;
 }

--- a/shorebird_code_push/lib/src/updater.dart
+++ b/shorebird_code_push/lib/src/updater.dart
@@ -42,4 +42,11 @@ class Updater {
   /// Frees an update result allocated by the updater.
   void freeUpdateResult(Pointer<UpdateResult> ptr) =>
       bindings.shorebird_free_update_result(ptr);
+
+  /// Requests that the engine restart the app's Dart code, booting from the
+  /// next boot patch. Returns true if the engine accepted the request.
+  /// Throws an [ArgumentError] if running against an engine that does not
+  /// export `shorebird_restart_app` (i.e. engines without hot restart
+  /// support).
+  bool restartApp() => bindings.shorebird_restart_app();
 }

--- a/shorebird_code_push/pubspec.yaml
+++ b/shorebird_code_push/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shorebird_code_push
 description: Check for and download Shorebird code push updates from your app.
-version: 2.0.7
+version: 2.1.0
 homepage: https://shorebird.dev
 repository: https://github.com/shorebirdtech/updater/tree/main/shorebird_code_push
 

--- a/shorebird_code_push/test/integration/all_test.dart
+++ b/shorebird_code_push/test/integration/all_test.dart
@@ -187,5 +187,43 @@ void main() {
       // next_boot_patch was cleared by the rollback.
       expect(await updater.readNextPatch(), isNull);
     });
+
+    // Drives the full production hot restart request path:
+    // ShorebirdUpdater.restartApp() → shorebird_restart_app FFI →
+    // the Rust relay → the engine-registered restart handler. In
+    // production the handler tears down and relaunches the Dart
+    // isolate; here a fake handler records the request.
+    test('restartApp relays to the engine-registered restart handler',
+        () async {
+      final reason = skipReason;
+      if (reason != null) {
+        markTestSkipped(reason);
+        return;
+      }
+
+      engine.init(tmp: tmp, server: server);
+      final updater = engine.createUpdater();
+
+      // No handler registered (e.g. an engine without hot restart
+      // support): the request is rejected.
+      expect(await updater.restartApp(), isFalse);
+
+      // The engine registers a handler at startup and accepts the
+      // request.
+      engine.installRestartHandler();
+      expect(await updater.restartApp(), isTrue);
+      expect(engine.restartRequestCount, 1);
+
+      // The engine can also reject the request (e.g. unsupported
+      // multi-engine configuration).
+      engine.installRestartHandler(accept: false);
+      expect(await updater.restartApp(), isFalse);
+      expect(engine.restartRequestCount, 1);
+
+      // engine.reset() (shorebird_test_reset) removes the handler, as
+      // process teardown would.
+      engine.reset();
+      expect(await updater.restartApp(), isFalse);
+    });
   });
 }

--- a/shorebird_code_push/test/integration/generated/test_hooks_bindings.g.dart
+++ b/shorebird_code_push/test/integration/generated/test_hooks_bindings.g.dart
@@ -2414,6 +2414,38 @@ class TestHooksBindings {
   late final _shorebird_test_simulate_successful_launch =
       _shorebird_test_simulate_successful_launchPtr
           .asFunction<void Function()>();
+
+  /// Installs a fake engine restart handler, as the Shorebird engine does
+  /// at startup. `accept` controls whether the handler reports the restart
+  /// as scheduled (the value returned to `shorebird_restart_app` callers).
+  /// Also resets the request counter. `shorebird_test_reset` removes the
+  /// handler again.
+  void shorebird_test_install_restart_handler(
+    bool accept,
+  ) {
+    return _shorebird_test_install_restart_handler(
+      accept,
+    );
+  }
+
+  late final _shorebird_test_install_restart_handlerPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Bool)>>(
+          'shorebird_test_install_restart_handler');
+  late final _shorebird_test_install_restart_handler =
+      _shorebird_test_install_restart_handlerPtr
+          .asFunction<void Function(bool)>();
+
+  /// The number of restart requests the fake handler has received since it
+  /// was last installed.
+  int shorebird_test_restart_request_count() {
+    return _shorebird_test_restart_request_count();
+  }
+
+  late final _shorebird_test_restart_request_countPtr =
+      _lookup<ffi.NativeFunction<ffi.UintPtr Function()>>(
+          'shorebird_test_restart_request_count');
+  late final _shorebird_test_restart_request_count =
+      _shorebird_test_restart_request_countPtr.asFunction<int Function()>();
 }
 
 typedef __builtin_va_list = ffi.Pointer<ffi.Char>;
@@ -4077,6 +4109,8 @@ const int __MAC_26_3 = 260300;
 
 const int __MAC_26_4 = 260400;
 
+const int __MAC_26_5 = 260500;
+
 const int __IPHONE_2_0 = 20000;
 
 const int __IPHONE_2_1 = 20100;
@@ -4263,6 +4297,8 @@ const int __IPHONE_26_3 = 260300;
 
 const int __IPHONE_26_4 = 260400;
 
+const int __IPHONE_26_5 = 260500;
+
 const int __WATCHOS_1_0 = 10000;
 
 const int __WATCHOS_2_0 = 20000;
@@ -4386,6 +4422,8 @@ const int __WATCHOS_26_2 = 260200;
 const int __WATCHOS_26_3 = 260300;
 
 const int __WATCHOS_26_4 = 260400;
+
+const int __WATCHOS_26_5 = 260500;
 
 const int __TVOS_9_0 = 90000;
 
@@ -4511,6 +4549,8 @@ const int __TVOS_26_3 = 260300;
 
 const int __TVOS_26_4 = 260400;
 
+const int __TVOS_26_5 = 260500;
+
 const int __BRIDGEOS_2_0 = 20000;
 
 const int __BRIDGEOS_3_0 = 30000;
@@ -4589,6 +4629,8 @@ const int __BRIDGEOS_10_3 = 100300;
 
 const int __BRIDGEOS_10_4 = 100400;
 
+const int __BRIDGEOS_26_5 = 260500;
+
 const int __DRIVERKIT_19_0 = 190000;
 
 const int __DRIVERKIT_20_0 = 200000;
@@ -4641,6 +4683,8 @@ const int __DRIVERKIT_25_3 = 250300;
 
 const int __DRIVERKIT_25_4 = 250400;
 
+const int __DRIVERKIT_25_5 = 250500;
+
 const int __VISIONOS_1_0 = 10000;
 
 const int __VISIONOS_1_1 = 10100;
@@ -4674,6 +4718,8 @@ const int __VISIONOS_26_2 = 260200;
 const int __VISIONOS_26_3 = 260300;
 
 const int __VISIONOS_26_4 = 260400;
+
+const int __VISIONOS_26_5 = 260500;
 
 const int MAC_OS_X_VERSION_10_0 = 1000;
 
@@ -4829,6 +4875,8 @@ const int MAC_OS_VERSION_26_3 = 260300;
 
 const int MAC_OS_VERSION_26_4 = 260400;
 
+const int MAC_OS_VERSION_26_5 = 260500;
+
 const int __AVAILABILITY_VERSIONS_VERSION_HASH = 93585900;
 
 const String __AVAILABILITY_VERSIONS_VERSION_STRING = 'Local';
@@ -4837,7 +4885,7 @@ const String __AVAILABILITY_FILE = 'AvailabilityVersions.h';
 
 const int __MAC_OS_X_VERSION_MIN_REQUIRED = 260000;
 
-const int __MAC_OS_X_VERSION_MAX_ALLOWED = 260400;
+const int __MAC_OS_X_VERSION_MAX_ALLOWED = 260500;
 
 const int __ENABLE_LEGACY_MAC_AVAILABILITY = 1;
 

--- a/shorebird_code_push/test/integration/helpers/test_engine.dart
+++ b/shorebird_code_push/test/integration/helpers/test_engine.dart
@@ -103,6 +103,17 @@ class TestEngine {
   void simulateSuccessfulLaunch() =>
       _bindings.shorebird_test_simulate_successful_launch();
 
+  /// Installs a fake engine restart handler, as the Shorebird engine
+  /// does at startup. [accept] controls whether the handler reports the
+  /// restart as scheduled. [reset] removes it again.
+  void installRestartHandler({bool accept = true}) =>
+      _bindings.shorebird_test_install_restart_handler(accept);
+
+  /// The number of restart requests the fake handler has received since
+  /// [installRestartHandler] was last called.
+  int get restartRequestCount =>
+      _bindings.shorebird_test_restart_request_count();
+
   /// Builds a [ShorebirdUpdater] suitable for tests.
   ///
   /// FFI calls run in a sub-isolate via `Isolate.run` (the same dispatch

--- a/shorebird_code_push/test/src/shorebird_updater_io_test.dart
+++ b/shorebird_code_push/test/src/shorebird_updater_io_test.dart
@@ -638,5 +638,68 @@ void main() {
         });
       });
     });
+
+    group('restartApp', () {
+      group('when updater is unavailable', () {
+        setUp(() {
+          when(updater.currentPatchNumber).thenThrow(Exception('oops'));
+        });
+
+        test(
+          'returns false without calling the updater',
+          overridePrint((_) async {
+            shorebirdUpdater = ShorebirdUpdaterImpl(updater: updater, run: run);
+            await expectLater(
+              shorebirdUpdater.restartApp(),
+              completion(isFalse),
+            );
+            verifyNever(updater.restartApp);
+          }),
+        );
+      });
+
+      group('when the engine accepts the restart request', () {
+        setUp(() {
+          when(updater.currentPatchNumber).thenReturn(0);
+          when(updater.restartApp).thenReturn(true);
+          shorebirdUpdater = ShorebirdUpdaterImpl(updater: updater, run: run);
+        });
+
+        test('returns true', () async {
+          await expectLater(shorebirdUpdater.restartApp(), completion(isTrue));
+          verify(updater.restartApp).called(1);
+        });
+      });
+
+      group('when the engine rejects the restart request', () {
+        setUp(() {
+          when(updater.currentPatchNumber).thenReturn(0);
+          when(updater.restartApp).thenReturn(false);
+          shorebirdUpdater = ShorebirdUpdaterImpl(updater: updater, run: run);
+        });
+
+        test('returns false', () async {
+          await expectLater(shorebirdUpdater.restartApp(), completion(isFalse));
+          verify(updater.restartApp).called(1);
+        });
+      });
+
+      group('when the engine does not support hot restart', () {
+        setUp(() {
+          when(updater.currentPatchNumber).thenReturn(0);
+          // Engines that predate hot restart support don't export the
+          // symbol; the late-bound FFI lookup throws an ArgumentError.
+          when(updater.restartApp).thenThrow(
+            ArgumentError('Failed to lookup symbol shorebird_restart_app'),
+          );
+          shorebirdUpdater = ShorebirdUpdaterImpl(updater: updater, run: run);
+        });
+
+        test('returns false', () async {
+          await expectLater(shorebirdUpdater.restartApp(), completion(isFalse));
+          verify(updater.restartApp).called(1);
+        });
+      });
+    });
   });
 }

--- a/shorebird_code_push/test/src/updater_test.dart
+++ b/shorebird_code_push/test/src/updater_test.dart
@@ -124,5 +124,17 @@ void main() {
         ).called(1);
       });
     });
+
+    group('restartApp', () {
+      test('forwards the result of shorebird_restart_app', () {
+        when(() => updaterBindings.shorebird_restart_app()).thenReturn(true);
+        expect(updater.restartApp(), isTrue);
+
+        when(() => updaterBindings.shorebird_restart_app()).thenReturn(false);
+        expect(updater.restartApp(), isFalse);
+
+        verify(() => updaterBindings.shorebird_restart_app()).called(2);
+      });
+    });
   });
 }


### PR DESCRIPTION
Adds the updater side of hot restart: applying a downloaded patch by restarting the app's Dart code in place, without the user relaunching the app.

The updater cannot restart the Dart VM itself, only the engine can. This PR adds the relay between the two:

- `shorebird_set_restart_handler` (engine C surface): the engine registers a restart handler at startup.
- `shorebird_restart_app` (Dart C surface): called by `package:shorebird_code_push` over FFI, relays to the handler. Returns false when no handler is registered (old engines, debug builds, unsupported configurations), so existing apps degrade gracefully and the patch still applies on the next launch.
- `ShorebirdUpdater.restartApp()`: new public API in `shorebird_code_push` (bumped to 2.1.0), with README, example app button, and web/unavailable stubs.

No changes to the boot state machine were needed: a hot restart is just a second launch cycle (`report_launch_start` then `report_launch_success`/`report_launch_failure`) in one process, which also gives hot restarts the same crash rollback protection as cold boots. The once-per-process guarding of those calls lives in the engine, not here.

Design notes: `docs/hot_restart.md`.

## Testing

- Rust unit tests for the handler relay (`library/src/restart.rs`) and for the second launch cycle contract (`hot_restart_tests` in `library/src/updater.rs`), including rollback on a failed restart.
- Dart unit tests for `restartApp()` including the missing-symbol (old engine) path.
- A Dart integration test driving the full FFI round trip through the real Rust library, using a fake engine handler added to `library_test_hooks`.

## Landing order

The engine half is in the flutter fork (PR to follow). Merge this first, then roll `updater_rev` in the fork's DEPS. The current pin (1f85c4a) is this branch's parent, so the roll is a fast forward.
